### PR TITLE
Closing of issues raised

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,18 +56,22 @@ To use the Memory back-end plug, include the following in the <config-file>:
 
 .. code:: python
 
-    "backend": {
-        "type": "memory",
-        "data_file": <path to json file with initial data>
+    {
+        "backend": {
+            "type": "memory",
+            "data_file": <path to json file with initial data>
+        }
     }
 
 To use the Mongo DB back-end plug, include the following in the <config-file>:
 
 .. code:: python
 
-    "backend": {
-        "type": "mongodb",
-        "url": <Mongo DB server url>  # e.g., "mongodb://localhost:27017/"
+    {
+        "backend": {
+            "type": "mongodb",
+            "url": <Mongo DB server url>  # e.g., "mongodb://localhost:27017/"
+        }
     }
 
 *Note: A Mongo DB should be available at some URL when using the Mongo DB back-end*

--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -4,8 +4,10 @@ import logging
 auth = None
 _CONFIG = None
 
+
 def get_config():
     return _CONFIG
+
 
 def init(config):
     logging.basicConfig(level=10)
@@ -24,23 +26,26 @@ def init(config):
     global auth
     if "auth" in config:
         try:
-            auth = importlib.import_module( config["auth"] )
-        except:
+            auth = importlib.import_module(config["auth"])
+
+        except Exception:
             raise ValueError("Unknown authentication type {0} for TAXII server ".format(config["auth"]))
+
     else:
         from flask_httpauth import HTTPBasicAuth
         auth = HTTPBasicAuth()
 
-	if "users" in config:
+    if "users" in config:
 
-            @auth.get_password
-            def get_pwd(username):
-                users = config["users"]
-                if username in users:
-                    return users.get(username)
-                return None
-        else:
-            raise ValueError("No \"users\" entry found in configuration file")
+        @auth.get_password
+        def get_pwd(username):
+            users = config["users"]
+            if username in users:
+                return users.get(username)
+            return None
+
+    else:
+        raise ValueError("No \"users\" entry found in configuration file")
 
     global _BACKEND
 
@@ -73,10 +78,13 @@ def init(config):
     else:
         raise ValueError("Unknown backend {0} for TAXII server ".format(backend_config["type"]))
 
+
 _BACKEND = None
+
 
 def get_backend():
     return _BACKEND
+
 
 def register_blueprints(application_instance):
     logging.debug("Registering blueprints")

--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -1,62 +1,86 @@
-from flask import Flask
-from flask_httpauth import HTTPBasicAuth
+import importlib
+import logging
 
-from medallion.backends.memory_backend import MemoryBackend
-
-application_instance = Flask(__name__)
-auth = HTTPBasicAuth()
-
+auth = None
 _CONFIG = None
-
-
-def set_config(config):
-    global _CONFIG
-    _CONFIG = config
-
 
 def get_config():
     return _CONFIG
 
+def init(config):
+    logging.basicConfig(level=10)
 
-def connect_to_backend(config_info):
-    if "type" not in config_info:
-        raise ValueError("No backend for the TAXII server was provided")
-    if config_info["type"] == "memory":
-        be = MemoryBackend()
-        be.load_data_from_file(config_info["data_file"])
-        return be
-    elif config_info["type"] == "mongodb":
+    logging.debug("Initializing configuration using {0}".format(config))
+
+    if "backend" not in config:
+        raise ValueError("No backend was specified in the confinguration")
+
+    if "type" not in config['backend']:
+        raise ValueError("No backend type for the TAXII server was provided")
+
+    global _CONFIG
+    _CONFIG = config
+
+    global auth
+    if "auth" in config:
+        try:
+            auth = importlib.import_module( config["auth"] )
+        except:
+            raise ValueError("Unknown authentication type {0} for TAXII server ".format(config["auth"]))
+    else:
+        from flask_httpauth import HTTPBasicAuth
+        auth = HTTPBasicAuth()
+
+	if "users" in config:
+
+            @auth.get_password
+            def get_pwd(username):
+                users = config["users"]
+                if username in users:
+                    return users.get(username)
+                return None
+        else:
+            raise ValueError("No \"users\" entry found in configuration file")
+
+    global _BACKEND
+
+    backend_config = config["backend"]
+    if "type" not in backend_config:
+        raise ValueError("No backend type for the TAXII server was provided")
+
+    if backend_config["type"] == "memory":
+        from medallion.backends.memory_backend import MemoryBackend
+        _BACKEND = MemoryBackend()
+        _BACKEND.load_data_from_file(backend_config["data_file"])
+    elif backend_config["type"] == "mongodb":
         try:
             from medallion.backends.mongodb_backend import MongoBackend
         except ImportError:
             raise ImportError("The pymongo package is not available")
-        return MongoBackend(config_info["url"])
-    else:
-        raise ValueError("Unknown backend %s for TAXII server ".format(config_info["backend"]))
+        _BACKEND = MongoBackend(backend_config["url"])
+    elif backend_config["type"] == "module":
+        if "module" not in backend_config:
+            raise ValueError("No module parameter found in backend_config")
 
+        if "module_class" not in backend_config:
+            raise ValueError("No module_class parameter found in backend_config")
+
+        import importlib
+        mod = importlib.import_module(backend_config["module"])
+        class_ = getattr(mod, backend_config["module_class"])
+        _BACKEND = class_(backend_config)
+
+    else:
+        raise ValueError("Unknown backend {0} for TAXII server ".format(backend_config["type"]))
 
 _BACKEND = None
-
-
-def init_backend(config_info):
-    global _BACKEND
-    if _BACKEND is None:
-        _BACKEND = connect_to_backend(config_info)
-
 
 def get_backend():
     return _BACKEND
 
+def register_blueprints(application_instance):
+    logging.debug("Registering blueprints")
 
-@auth.get_password
-def get_pwd(username):
-    users = get_config()["users"]
-    if username in users:
-        return users.get(username)
-    return None
-
-
-def register_blueprints():
     from medallion.views import collections
     from medallion.views import discovery
     from medallion.views import manifest
@@ -66,6 +90,3 @@ def register_blueprints():
     application_instance.register_blueprint(discovery.mod)
     application_instance.register_blueprint(manifest.mod)
     application_instance.register_blueprint(objects.mod)
-
-
-register_blueprints()

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -20,12 +20,12 @@ class MemoryBackend(Backend):
 
     def load_data_from_file(self, filename):
         import os.path
-        if os.path.isfile(filename) and os.path.getsize(filename) > 0: 
+        if os.path.isfile(filename) and os.path.getsize(filename) > 0:
             try:
-                self.data = json.load( StringIO( open(filename, "r").read() ) )
-            except:
+                self.data = json.load(StringIO(open(filename, "r").read()))
+            except Exception:
                 raise ValueError("File " + filename + " contains invalid data")
-        
+
     def save_data_to_file(self, filename):
         with open(filename, 'w') as outfile:
             json.dump(self.data,

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -19,8 +19,13 @@ class MemoryBackend(Backend):
         self.data = {}
 
     def load_data_from_file(self, filename):
-        self.data = json.load(StringIO(open(filename, "r").read()))
-
+        import os.path
+        if os.path.isfile(filename) and os.path.getsize(filename) > 0: 
+            try:
+                self.data = json.load( StringIO( open(filename, "r").read() ) )
+            except:
+                raise ValueError("File " + filename + " contains invalid data")
+        
     def save_data_to_file(self, filename):
         with open(filename, 'w') as outfile:
             json.dump(self.data,

--- a/medallion/scripts/run.py
+++ b/medallion/scripts/run.py
@@ -4,8 +4,9 @@ import os.path
 import sys
 
 from flask import Flask, url_for, render_template
+from medallion import (init, register_blueprints)
 
-from medallion import (init,register_blueprints)
+
 def main():
 
     if len(sys.argv) < 2:
@@ -27,7 +28,7 @@ def main():
     application_instance = Flask(__name__)
 
     register_blueprints(application_instance)
-    
+
     application_instance.run(debug=True)
 
 

--- a/medallion/scripts/run.py
+++ b/medallion/scripts/run.py
@@ -1,20 +1,33 @@
 import json
 import sys
+import os.path
+import sys
 
-from medallion import (application_instance, get_config, init_backend,
-                       set_config)
+from flask import Flask, url_for, render_template
 
-
+from medallion import (init,register_blueprints)
 def main():
 
     if len(sys.argv) < 2:
-        raise ValueError("No config file")
+        raise ValueError("No config file specified")
+
     config_file_path = sys.argv[1]
-    with open(config_file_path, 'r') as f:
-        set_config(json.load(f))
+    if os.path.isfile(config_file_path) and os.path.getsize(config_file_path) > 0:
+        with open(config_file_path, 'r') as f:
+            config = None
+            try:
+                config = json.load(f)
+            except ValueError:
+                raise ValueError("File {0} contains invalid JSON".format(config_file_path))
+            init(config)
 
-    init_backend(get_config()['backend'])
+    else:
+        raise ValueError("File {0} is empty or not present".format(config_file_path))
 
+    application_instance = Flask(__name__)
+
+    register_blueprints(application_instance)
+    
     application_instance.run(debug=True)
 
 

--- a/medallion/test/test_memory_backend.py
+++ b/medallion/test/test_memory_backend.py
@@ -33,7 +33,7 @@ API_OBJECTS_2 = {
 
 @pytest.fixture(scope="module")
 def backend(data_file=DATA_FILE):
-    init_backend({"type": "memory", "data_file": data_file})
+    init({"backend":{"type": "memory", "data_file": data_file}, "users":[]})
     return get_backend()
 
 
@@ -171,7 +171,7 @@ def test_saving_data_file(backend):
         backend.save_data_to_file(f.name)
         assert os.path.isfile(f.name)
 
-        init_backend({"type": "memory", "data_file": f.name})
+        init({"backend":{"type": "memory", "data_file": f.name},"users":[]})
         backend2 = get_backend()
         obj = backend2.get_object("trustgroup1", "91a7b528-80eb-42ed-a74d-c6fbd5a26116", new_id, None, ("version",))
         assert obj["objects"][0]["id"] == new_id

--- a/medallion/test/test_memory_backend.py
+++ b/medallion/test/test_memory_backend.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from medallion import get_backend, init_backend
+from medallion import get_backend, init
 from medallion.utils import common
 
 DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "default_data.json")

--- a/medallion/test/test_mongodb_backend.py
+++ b/medallion/test/test_mongodb_backend.py
@@ -32,7 +32,7 @@ API_OBJECTS_2 = {
 @pytest.fixture(scope="module")
 def backend():
     reset_db()
-    init_backend({"type": "mongodb", "url": "mongodb://localhost:27017/"})
+    init({"backend":{"type": "mongodb", "url": "mongodb://localhost:27017/"},"users":[]})
     return get_backend()
 
 

--- a/medallion/test/test_mongodb_backend.py
+++ b/medallion/test/test_mongodb_backend.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from medallion import get_backend, init_backend
+from medallion import get_backend, init
 from medallion.test.data.initialize_mongodb import reset_db
 from medallion.utils import common
 


### PR DESCRIPTION
Add error handling messages for when things are not specified
Refactor to abstract away the Flask endpoint allowing medallion to be run as a library in an already-existing Flask application ( see issue #14 )
Allow one to plug-in a backend python module without editing the source code by specifying it in config.json ( see issue #13 )