### PR TITLE
Make medallion script run externally visible

### DIFF
--- a/medallion/scripts/run.py
+++ b/medallion/scripts/run.py
@@ -15,7 +15,7 @@ def main():
 
     init_backend(get_config()['backend'])
 
-    application_instance.run(debug=True)
+    application_instance.run(host="0.0.0.0", debug=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is necessary if we want to run in Docker. Without this, Flask will run on 127.0.0.1, which won't be accessible outside a Docker container.