### PR TITLE
Bugfix: add STIX2 bundle via cti-taxii-client

### DIFF
--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -187,7 +187,17 @@ class MemoryBackend(Backend):
             status = generate_status(request_time, "complete", succeeded,
                                      failed, pending, successes_ids=successes,
                                      failures=failures)
-            api_info["status"].append(status)
+            
+            if isinstance(api_info["status"], list):
+                api_info["status"].append(status)
+
+            elif isinstance(api_info["status"], dict):
+                api_info["status"].update(status)
+
+            else:
+                raise TypeError("api_info[\"status\"] is not an instance of dict or list. Enable to add status to object type: '{}'".format(
+                    type(api_info["status"]).__name__))
+            
             return status
 
     def get_object(self, api_root, id_, object_id, filter_args, allowed_filters):


### PR DESCRIPTION
Adding STIX bundle via "cti-taxii-client", the server returns http error code 500.

```
[17/May/2019 10:10:25] "POST /info/collections/c0616fa4-fa24-4bb7-91d7-4ebb13a176b2/objects/ HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2309, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2295, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1741, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.5/dist-packages/flask_httpauth.py", line 104, in decorated
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/medallion/views/objects.py", line 50, in get_or_add_objects
    status = current_app.medallion_backend.add_objects(api_root, id_, request.get_json(force=True), request_time)
  File "/usr/local/lib/python3.5/dist-packages/medallion/backends/memory_backend.py", line 191, in add_objects
    api_info["status"].append(status)
AttributeError: 'dict' object has no attribute 'append'
```

The new code check if api_info["status"] is an instance of list (.append(status)), dict (.update(status)) or other (raising error).
This way, the code is backward compatible.