### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,12 @@ Medallion provides a command-line interface to start the TAXII Server::
 To run *medallion*::
 
     $ python medallion/scripts/run.py <config-file>
+    
+If you plan on running and accessing medallion on localhost, be sure to specify 
+
+    $ --port 80
+    
+as the taxii client only accesses servers on port 80.
 
 The <config_file> contains:
 
@@ -129,6 +135,19 @@ The authorization is enabled using the python package
 `flask_httpauth <https://flask-httpauth.readthedocs.io>`_.
 Authorization could be enhanced by changing the method "decorated" using
 @auth.get_password in medallion/__init__.py
+
+Configs may also contain a "taxii" section as well, as shown below:
+
+.. code:: python
+
+    {
+        "taxii": {
+           "max_page_size": 100
+        }
+    }
+    
+All TAXII servers require a config, though if any of the sections specified above 
+are missing, they will be filled with default values.  
 
 We welcome contributions for other back-end plugins.
 

--- a/README.rst
+++ b/README.rst
@@ -73,11 +73,11 @@ Medallion provides a command-line interface to start the TAXII Server::
 To run *medallion*::
 
     $ python medallion/scripts/run.py <config-file>
-    
-If you plan on running and accessing medallion on localhost, be sure to specify 
+
+If you plan on running and accessing medallion on localhost, be sure to specify
 
     $ --port 80
-    
+
 as the taxii client only accesses servers on port 80.
 
 The <config_file> contains:
@@ -145,9 +145,9 @@ Configs may also contain a "taxii" section as well, as shown below:
            "max_page_size": 100
         }
     }
-    
-All TAXII servers require a config, though if any of the sections specified above 
-are missing, they will be filled with default values.  
+
+All TAXII servers require a config, though if any of the sections specified above
+are missing, they will be filled with default values.
 
 We welcome contributions for other back-end plugins.
 


### PR DESCRIPTION
Added a section to specify that configs usually have a "taxii" section, to mitigate issues like [#57](https://github.com/oasis-open/cti-taxii-server/issues/57#issue-479843439). Also added a line to say that default values will be plugged in if any sections are missing.