### PR TITLE
Updated basic_filter to be in line with 2.1 spec, updated tests and default_data to match spec, and fixed some issues with the memory_backend pertaining to 2.1 objects

### DIFF
--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -45,7 +45,7 @@ class MemoryBackend(Backend):
             if "id" in collection and collection_id == collection["id"]:
                 version = determine_version(new_obj, request_time)
                 request_time = format_datetime(request_time)
-                media_type = media_type_fmt.format(new_obj.get("spec_version", "2.0"))
+                media_type = media_type_fmt.format(new_obj.get("spec_version", "2.1"))
 
                 # version is a single value now, therefore a new manifest is always created
                 collection["manifest"].append(

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -143,7 +143,6 @@ class MemoryBackend(Backend):
             return create_resource("objects", objs)
 
     def add_objects(self, api_root, collection_id, objs, request_time):
-        print(request_time)
         if api_root in self.data:
             api_info = self._get(api_root)
             collections = api_info.get("collections", [])

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -3,7 +3,9 @@ import json
 
 from ..exceptions import ProcessingError
 from ..filters.basic_filter import BasicFilter
-from ..utils.common import create_resource, determine_version, format_datetime, generate_status, generate_status_details, iterpath
+from ..utils.common import (create_resource, determine_version,
+                            format_datetime, generate_status,
+                            generate_status_details, iterpath)
 from .base import Backend
 
 

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -59,7 +59,7 @@ class MemoryBackend(Backend):
 
     def get_collections(self, api_root):
         if api_root not in self.data:
-            return None, None  # must return None so 404 is raised
+            return None  # must return None so 404 is raised
 
         api_info = self._get(api_root)
         collections = copy.deepcopy(api_info.get("collections", []))
@@ -141,6 +141,7 @@ class MemoryBackend(Backend):
             return create_resource("objects", objs)
 
     def add_objects(self, api_root, collection_id, objs, request_time):
+        print(request_time)
         if api_root in self.data:
             api_info = self._get(api_root)
             collections = api_info.get("collections", [])
@@ -186,7 +187,7 @@ class MemoryBackend(Backend):
                         raise ProcessingError("While processing supplied content, an error occurred", 422, e)
 
             status = generate_status(
-                request_time, "complete", succeeded,
+                format_datetime(request_time), "complete", succeeded,
                 failed, pending, successes=successes,
                 failures=failures,
             )

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -5,7 +5,9 @@ from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 
 from ..exceptions import MongoBackendError, ProcessingError
 from ..filters.mongodb_filter import MongoDBFilter
-from ..utils.common import create_resource, determine_version, format_datetime, generate_status, generate_status_details
+from ..utils.common import (create_resource, determine_version,
+                            format_datetime, generate_status,
+                            generate_status_details)
 from .base import Backend
 
 # Module-level logger

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -43,7 +43,7 @@ class MongoBackend(Backend):
         media_type_fmt = "application/vnd.oasis.stix+json; version={}"
 
         version = determine_version(new_obj, request_time)
-        media_type = media_type_fmt.format(new_obj.get("spec_version", "2.0"))
+        media_type = media_type_fmt.format(new_obj.get("spec_version", "2.1"))
 
         # version is a single value now, therefore a new manifest is created always
         manifest_info.insert_one(

--- a/medallion/filters/basic_filter.py
+++ b/medallion/filters/basic_filter.py
@@ -128,9 +128,8 @@ class BasicFilter(object):
                 obj_time = convert_to_stix_datetime(obj[obj_att])
                 if obj_time in actual_dates:
                     pos = bisect.bisect_left(id_track, obj["id"])
-                    if not res or pos > len(id_track) - 1 or id_track[pos] != obj["id"]:
-                        id_track.insert(pos, obj["id"])
-                        res.insert(pos, obj)
+                    id_track.insert(pos, obj["id"])
+                    res.insert(pos, obj)
             final_match = res
             final_track = id_track
 

--- a/medallion/filters/basic_filter.py
+++ b/medallion/filters/basic_filter.py
@@ -1,32 +1,24 @@
 import copy
-import datetime as dt
 
 from ..utils.common import convert_to_stix_datetime
+
+
+def find_att(obj):
+    if "version" in obj:
+        return "version"
+    elif "modified" in obj:
+        return "modified"
+    elif "created" in obj:
+        return "created"
+    else:
+        # TO DO: PUT DEFAULT VALUE HERE
+        pass
 
 
 class BasicFilter(object):
 
     def __init__(self, filter_args):
         self.filter_args = filter_args
-
-    @staticmethod
-    def _belongs_in_class(c, obj):
-        return c[0]["id"] == obj["id"]
-
-    @staticmethod
-    def _equivalence_partition_by_id(initial_results):
-        classes = []
-        for o in initial_results:  # for each object
-            # find the class it is in
-            found = False
-            for c in classes:
-                if BasicFilter._belongs_in_class(c, o):  # is it equivalent to this class?
-                    c.append(o)
-                    found = True
-                    break
-            if not found:  # it is in a new class
-                classes.append([o])
-        return classes
 
     @staticmethod
     def filter_by_id(data, id_):
@@ -41,10 +33,39 @@ class BasicFilter(object):
         return match_objects
 
     @staticmethod
+    def filter_by_added_after(data, manifest_info, added_after_date):
+        added_after_timestamp = convert_to_stix_datetime(added_after_date)
+        new_results = []
+        # for manifest objects
+        if manifest_info is None:
+            for obj in data:
+                if obj in new_results:
+                    continue
+                added_date_timestamp = convert_to_stix_datetime(obj["date_added"])
+                if added_date_timestamp > added_after_timestamp:
+                    new_results.append(obj)
+        # for other objects with manifests
+        else:
+            for obj in data:
+                if obj in new_results:
+                    continue
+                for item in manifest_info:
+                    if item["id"] == obj["id"]:
+                        added_date_timestamp = convert_to_stix_datetime(item["date_added"])
+                        if added_date_timestamp > added_after_timestamp:
+                            new_results.append(obj)
+        return new_results
+
+    @staticmethod
+    # this could be put together into one for loop
+    # is the ordering of the results important?
     def filter_by_version(data, version):
-        # There can be more than one filter, using v_filter for looping through
-        # each filter. For example ?match[version]=first,last
         match_objects = []
+        # return most recent object versions unless otherwise specified
+        if version is None:
+            version = "last"
+        if "first" not in version and "last" not in version:
+            version = version + ",last"
         version_indicators = version.split(",")
 
         if "all" in version_indicators:
@@ -52,86 +73,36 @@ class BasicFilter(object):
             return data
 
         actual_dates = [x for x in version_indicators if x != "first" and x != "last"]
+        # if a specific version is given, filter for objects with that value
+        if actual_dates:
+            for obj in data:
+                obj_att = find_att(obj)
+                if obj[obj_att] in actual_dates:
+                    match_objects.append(obj)
+        else:
+            match_objects = copy.deepcopy(data)
 
-        first = last = None
-        t_first = t_last = None
+        if "first" in version_indicators and match_objects:
+            for obj in match_objects:
+                obj_att = find_att(obj)
+                obj_time = convert_to_stix_datetime(obj[obj_att])
+                for compare in match_objects:
+                    comp_att = find_att(compare)
+                    comp_time = convert_to_stix_datetime(compare[comp_att])
+                    if compare is not obj and compare["id"] == obj["id"] and comp_time <= obj_time:
+                        match_objects.remove(obj)
+                        break
 
-        for obj in data:
-            if obj["id"].startswith("marking-definition--"):
-                prop = "created"
-            else:
-                prop = "modified"
-            time_of_obj = dt.datetime.strptime(obj[prop], "%Y-%m-%dT%H:%M:%S.%fZ")
-            if first is None:
-                first = last = obj
-                t_first = time_of_obj
-                t_last = time_of_obj
-            else:
-                if time_of_obj < t_first:
-                    first = obj
-                    t_first = time_of_obj
-                elif time_of_obj > t_last:
-                    last = obj
-                    t_last = time_of_obj
-
-            if obj[prop] in actual_dates:
-                match_objects.append(obj)
-
-        if "first" in version_indicators:
-            match_objects.append(first)
-
-        if "last" in version_indicators:
-            match_objects.append(last)
-
-        return match_objects
-
-    @staticmethod
-    def is_manifest_entry(obj):
-        # "id" is required, all other properties are optional.
-        return any(prop in obj for prop in ("id", "date_added", "versions", "media_types"))
-
-    @staticmethod
-    def filter_manifest_entries_by_version(data, version):
-        match_objects = []
-        version_indicators = version.split(",")
-
-        if "all" in version_indicators:
-            # if "all" is in the list, just return everything
-            return data
-
-        actual_dates = [x for x in version_indicators if x != "first" and x != "last"]
-        for obj in data:
-            versions_returned = []
-            first = last = None
-            t_first = t_last = None
-
-            for t in obj["versions"]:
-                timestamp = dt.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%fZ")
-                if first is None:
-                    first = last = t
-                    t_first = timestamp
-                    t_last = timestamp
-                else:
-                    if timestamp < t_first:
-                        first = t
-                        t_first = timestamp
-                    elif timestamp > t_last:
-                        last = t
-                        t_last = timestamp
-
-                if t in actual_dates:
-                    versions_returned.append(t)
-
-            if "first" in version_indicators:
-                versions_returned.append(first)
-
-            if "last" in version_indicators:
-                versions_returned.append(last)
-
-            if versions_returned:
-                return_object = copy.deepcopy(obj)
-                return_object["versions"] = versions_returned
-                match_objects.append(return_object)
+        if match_objects and "last" in version_indicators:
+            for obj in match_objects:
+                obj_att = find_att(obj)
+                obj_time = convert_to_stix_datetime(obj[obj_att])
+                for compare in match_objects:
+                    comp_att = find_att(compare)
+                    comp_time = convert_to_stix_datetime(compare[comp_att])
+                    if compare is not obj and compare["id"] == obj["id"] and comp_time >= obj_time:
+                        match_objects.remove(obj)
+                        break
 
         return match_objects
 
@@ -148,10 +119,30 @@ class BasicFilter(object):
 
         return match_objects
 
+    @staticmethod
+    def filter_by_spec_version(data, spec_):
+        spec_ = spec_.split(",")
+
+        match_objects = []
+
+        for obj in data:
+            if "spec_version" in obj and any(s == obj["spec_version"] for s in spec_):
+                match_objects.append(obj)
+            elif "media_type" in obj and any(s == obj["media_type"].split("version=")[1] for s in spec_):
+                # this is assuming all manifests will have the media_type attribute
+                # change this if there is another way
+                match_objects.append(obj)
+
+        return match_objects
+
     def process_filter(self, data, allowed, manifest_info):
         filtered_by_type = []
         filtered_by_id = []
+        filtered_by_version = []
+        filtered_by_spec_version = []
+        filtered_by_added_after = []
 
+        # match for type and id filters first
         match_type = self.filter_args.get("match[type]")
         if match_type and "type" in allowed:
             filtered_by_type = self.filter_by_type(data, match_type)
@@ -160,51 +151,38 @@ class BasicFilter(object):
         if match_id and "id" in allowed:
             filtered_by_id = self.filter_by_id(data, match_id)
 
-        results = []
+        initial_results = []
 
         if filtered_by_type and filtered_by_id:
             for type_match in filtered_by_type:
                 for id_match in filtered_by_id:
                     if type_match == id_match:
-                        results.append(type_match)
-
+                        initial_results.append(type_match)
         elif match_type:
             if filtered_by_type:
-                results.extend(filtered_by_type)
-
+                initial_results.extend(filtered_by_type)
         elif match_id:
             if filtered_by_id:
-                results.extend(filtered_by_id)
-
+                initial_results.extend(filtered_by_id)
         else:
-            results = data
+            initial_results = copy.deepcopy(data)
 
-        match_version = self.filter_args.get("match[version]")
-        if "version" in allowed:
-            if not match_version:
-                match_version = "last"
-            # manifest_info must be None when called from get_object_manifest()
-            if len(data) > 0 and self.is_manifest_entry(data[0]) and manifest_info is None:
-                results = self.filter_manifest_entries_by_version(results, match_version)
-            else:
-                new_results = []
-                for bucket in BasicFilter._equivalence_partition_by_id(results):
-                    new_results.extend(self.filter_by_version(bucket, match_version))
-                results = new_results
+        # match for spec_version
+        match_spec_version = self.filter_args.get("match[spec_version]")
+        if match_spec_version and "spec_version" in allowed:
+            filtered_by_spec_version = self.filter_by_spec_version(initial_results, match_spec_version)
+        else:
+            filtered_by_spec_version = initial_results
+
+        # match for added_after
         added_after_date = self.filter_args.get("added_after")
-        if added_after_date:
-            added_after_timestamp = convert_to_stix_datetime(added_after_date)
-            new_results = []
-            for obj in results:
-                info = None
-                for item in manifest_info:
-                    if item["id"] == obj["id"]:
-                        info = item
-                        break
-                if info:
-                    added_date_timestamp = convert_to_stix_datetime(info["date_added"])
-                    if added_date_timestamp > added_after_timestamp:
-                        new_results.append(obj)
-            return new_results
+        if added_after_date is not None:
+            filtered_by_added_after = self.filter_by_added_after(filtered_by_spec_version, manifest_info, added_after_date)
         else:
-            return results
+            filtered_by_added_after = filtered_by_spec_version
+
+        # match for version, and get rid of duplicates as appropriate
+        match_version = self.filter_args.get("match[version]")
+        filtered_by_version = self.filter_by_version(filtered_by_added_after, match_version)
+
+        return filtered_by_version

--- a/medallion/test/base_test.py
+++ b/medallion/test/base_test.py
@@ -27,7 +27,7 @@ class TaxiiTest(unittest.TestCase):
                 "valid_from": "2017-01-27T13:49:53.935382Z",
             },
         ],
-        "spec_version": "2.0",
+        "spec_version": "2.1",
         "type": "bundle",
     }
 

--- a/medallion/test/data/default_data.json
+++ b/medallion/test/data/default_data.json
@@ -12,10 +12,10 @@
     },
     "api1": {
         "information": {
-            "title": "General STIX 2.0 Collections",
+            "title": "General STIX 2.1 Collections",
             "description": "A repo for general STIX data.",
             "versions": [
-                "taxii-2.0"
+                "application/vnd.oasis.stix+json; version=2.1"
             ],
             "max_content_length": 9765625
         },
@@ -26,10 +26,10 @@
     },
     "api2": {
         "information": {
-            "title": "STIX 2.0 Indicator Collections",
+            "title": "STIX 2.1 Indicator Collections",
             "description": "A repo for general STIX data.",
             "versions": [
-                "taxii-2.0"
+                "application/vnd.oasis.stix+json; version=2.1"
             ],
             "max_content_length": 9765625
         },
@@ -43,41 +43,31 @@
             "title": "Malware Research Group",
             "description": "A trust group setup for malware researchers",
             "versions": [
-                "taxii-2.0"
+                "application/vnd.oasis.stix+json; version=2.1"
             ],
             "max_content_length": 9765625
         },
         "status": [
             {
-                "id": "2d086da7-4bdc-4f91-900e-d77486753710",
+                "id": "2d186da7-4bdc-4f91-900e-d77486753710",
                 "status": "pending",
                 "request_timestamp": "2016-11-02T12:34:34.12345Z",
                 "total_count": 4,
                 "success_count": 1,
                 "successes": [
-                    {
-                        "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade",
-                        "version": "2014-05-08T09:00:00.000Z"
-                    }
+                    "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade"
                 ],
                 "failure_count": 1,
                 "failures": [
                     {
                         "id": "malware--664fa29d-bf65-4f28-a667-bdb76f29ec98",
-                        "version": "2015-05-08T09:00:00.000Z",
                         "message": "Unable to process object"
                     }
                 ],
                 "pending_count": 2,
                 "pendings": [
-                    {
-                        "id": "indicator--252c7c11-daf2-42bd-843b-be65edca9f61",
-                        "version": "2016-08-08T09:00:00.000Z"
-                    },
-                    {
-                        "id": "relationship--045585ad-a22f-4333-af33-bfd503a683b5",
-                        "version": "2016-06-08T09:00:00.000Z"
-                    }
+                    "indicator--252c7c11-daf2-42bd-843b-be65edca9f61",
+                    "relationship--045585ad-a22f-4333-af33-bfd503a683b5"
                 ]
             },
             {
@@ -111,7 +101,6 @@
                         "created": "2017-01-27T13:49:53.997Z",
                         "description": "Poison Ivy",
                         "id": "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111",
-                        "spec_version": "2.1",
                         "labels": [
                             "remote-access-trojan"
                         ],
@@ -122,7 +111,6 @@
                     {
                         "created": "2014-05-08T09:00:00.000Z",
                         "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade",
-                        "spec_version": "2.1",
                         "labels": [
                             "file-hash-watchlist"
                         ],
@@ -135,7 +123,6 @@
                     {
                         "created": "2014-05-08T09:00:00.000Z",
                         "id": "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463",
-                        "spec_version": "2.1",
                         "modified": "2014-05-08T09:00:00.000Z",
                         "relationship_type": "indicates",
                         "source_ref": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade",
@@ -148,13 +135,17 @@
                         "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade",
                         "date_added": "2016-11-01T03:04:05Z",
                         "version": "2014-05-08T09:00:00.000Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     },
                     {
                         "id": "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111",
-                        "date_added": "2017-01-28T13:49:53.997Z",
+                        "date_added": "2017-01-27T13:49:53.997Z",
                         "version": "2017-01-27T13:49:53.997Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     }
                 ]
             },
@@ -171,8 +162,7 @@
                     {
                         "created": "2016-11-03T12:30:59.000Z",
                         "id": "indicator--d81f86b9-975b-bc0b-775e-810c5ad45a4f",
-                        "spec_version": "2.1",
-                        "indicator_types": [
+                        "labels": [
                             "url-watchlist"
                         ],
                         "modified": "2017-01-27T13:49:53.935Z",
@@ -181,12 +171,11 @@
                         "type": "indicator",
                         "valid_from": "2016-11-03T12:30:59.000Z"
                     },
-					{
+		    {
                         "created": "2016-11-03T12:30:59.000Z",
                         "description": "Accessing this url will infect your machine with malware.",
-						"id": "indicator--d81f86b9-975b-bc0b-775e-810c5ad45a4f",
-                        "spec_version": "2.1",
-                        "indicator_types": [
+			"id": "indicator--d81f86b9-975b-bc0b-775e-810c5ad45a4f",
+                        "labels": [
                             "url-watchlist"
                         ],
                         "modified": "2016-11-03T12:30:59.000Z",
@@ -201,20 +190,24 @@
                         "id": "indicator--d81f86b9-975b-bc0b-775e-810c5ad45a4f",
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2016-11-03T12:30:59.000Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     },
-                    {
+		    {
                         "id": "indicator--d81f86b9-975b-bc0b-775e-810c5ad45a4f",
-                        "date_added": "2017-12-31T13:49:53Z",
+                        "date_added": "2016-12-27T13:49:53Z",
                         "version": "2017-01-27T13:49:53.935Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     }
                 ]
             },
             {
                 "id": "64993447-4d7e-4f70-b94d-d7f33742ee63",
                 "title": "Secret Indicators",
-                "description": "Non accessible",
+                "description": "Non accessilble",
                 "can_read":false,
                 "can_write": false,
                 "media_types": [
@@ -225,11 +218,23 @@
                         "created": "2016-11-03T12:30:59.000Z",
                         "description": "Accessing this url will infect your machine with malware.",
                         "id": "indicator--b81f86b9-975b-bb0b-775e-810c5bd45b4f",
-                        "spec_version": "2.1",
-                        "indicator_types": [
+                        "labels": [
                             "url-watchlist"
                         ],
                         "modified": "2016-11-03T12:30:59.000Z",
+                        "name": "Malicious site hosting downloader",
+                        "pattern": "[url:value = 'http://z4z10farb.cn/4712']",
+                        "type": "indicator",
+                        "valid_from": "2017-01-27T13:49:53.935382Z"
+                    },
+		    {
+                        "created": "2016-11-03T12:30:59.000Z",
+                        "description": "Accessing this url will infect your machine with malware.",
+                        "id": "indicator--b81f86b9-975b-bb0b-775e-810c5bd45b4f",
+                        "labels": [
+                            "url-watchlist"
+                        ],
+                        "modified": "2017-01-27T13:49:53.935Z",
                         "name": "Malicious site hosting downloader",
                         "pattern": "[url:value = 'http://z4z10farb.cn/4712']",
                         "type": "indicator",
@@ -241,13 +246,17 @@
                         "id": "indicator--b81f86b9-975b-bb0b-775e-810c5bd45b4f",
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2016-11-03T12:30:59.000Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     },
-                    {
+		    {
                         "id": "indicator--b81f86b9-975b-bb0b-775e-810c5bd45b4f",
-                        "date_added": "2017-02-25T13:49:53Z",
+                        "date_added": "2016-12-27T13:49:53Z",
                         "version": "2017-01-27T13:49:53.935Z",
-                        "media_type": "application/vnd.oasis.stix+json; version=2.1"
+                        "media_types": [
+                            "application/vnd.oasis.stix+json; version=2.1"
+                        ]
                     }
                 ]
             }

--- a/medallion/test/data/default_data.json
+++ b/medallion/test/data/default_data.json
@@ -15,7 +15,7 @@
             "title": "General STIX 2.1 Collections",
             "description": "A repo for general STIX data.",
             "versions": [
-                "application/vnd.oasis.stix+json; version=2.1"
+                "application/taxii+json;version=2.1"
             ],
             "max_content_length": 9765625
         },
@@ -29,7 +29,7 @@
             "title": "STIX 2.1 Indicator Collections",
             "description": "A repo for general STIX data.",
             "versions": [
-                "application/vnd.oasis.stix+json; version=2.1"
+                "application/taxii+json;version=2.1"
             ],
             "max_content_length": 9765625
         },
@@ -43,19 +43,19 @@
             "title": "Malware Research Group",
             "description": "A trust group setup for malware researchers",
             "versions": [
-                "application/vnd.oasis.stix+json; version=2.1"
+                "application/taxii+json;version=2.1"
             ],
             "max_content_length": 9765625
         },
         "status": [
             {
-                "id": "2d186da7-4bdc-4f91-900e-d77486753710",
+                "id": "2d086da7-4bdc-4f91-900e-d77486753710",
                 "status": "pending",
                 "request_timestamp": "2016-11-02T12:34:34.12345Z",
                 "total_count": 4,
                 "success_count": 1,
                 "successes": [
-                    "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade"
+                    "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade"
                 ],
                 "failure_count": 1,
                 "failures": [
@@ -72,17 +72,17 @@
             },
             {
                 "id": "2d086da7-4bdc-4f91-900e-f4566be4b780",
-				"status": "pending",
-				"request_timestamp": "2016-11-02T12:34:34.12345Z",
+		"status": "pending",
+		"request_timestamp": "2016-11-02T12:34:34.12345Z",
                 "total_objects": 2,
-				"success_count": 0,
-				"successes": [
+		"success_count": 0,
+		"successes": [
                 ],
-				"failure_count": 0,
-				"failures": [
+		"failure_count": 0,
+		"failures": [
                 ],
-				"pending_count": 0,
-				"pendings": [
+		"pending_count": 0,
+		"pendings": [
                 ]
             }
         ],
@@ -94,7 +94,7 @@
                 "can_read": true,
                 "can_write": true,
                 "media_types": [
-                    "application/vnd.oasis.stix+json; version=2.1"
+                    "application/taxii+json;version=2.1"
                 ],
                 "objects": [
                     {
@@ -136,7 +136,7 @@
                         "date_added": "2016-11-01T03:04:05Z",
                         "version": "2014-05-08T09:00:00.000Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     },
                     {
@@ -144,7 +144,7 @@
                         "date_added": "2017-01-27T13:49:53.997Z",
                         "version": "2017-01-27T13:49:53.997Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     }
                 ]
@@ -156,7 +156,7 @@
                 "can_read": true,
                 "can_write": false,
                 "media_types": [
-                    "application/vnd.oasis.stix+json; version=2.1"
+                    "application/taxii+json;version=2.1"
                 ],
                 "objects": [
                     {
@@ -191,7 +191,7 @@
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2016-11-03T12:30:59.000Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     },
 		    {
@@ -199,7 +199,7 @@
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2017-01-27T13:49:53.935Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     }
                 ]
@@ -211,7 +211,7 @@
                 "can_read":false,
                 "can_write": false,
                 "media_types": [
-                    "application/vnd.oasis.stix+json; version=2.1"
+                    "application/taxii+json;version=2.1"
                 ],
                 "objects": [
                     {
@@ -247,7 +247,7 @@
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2016-11-03T12:30:59.000Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     },
 		    {
@@ -255,7 +255,7 @@
                         "date_added": "2016-12-27T13:49:53Z",
                         "version": "2017-01-27T13:49:53.935Z",
                         "media_types": [
-                            "application/vnd.oasis.stix+json; version=2.1"
+                            "application/taxii+json;version=2.1"
                         ]
                     }
                 ]

--- a/medallion/test/data/default_data.json
+++ b/medallion/test/data/default_data.json
@@ -55,19 +55,29 @@
                 "total_count": 4,
                 "success_count": 1,
                 "successes": [
-                    "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade"
-                ],
+		  {
+                    "id": "indicator--a932fcc6-e032-176c-126f-cb970a5a1ade",
+		    "version": "2018-05-27T12:02:41.312Z"
+		  }
+		],
                 "failure_count": 1,
                 "failures": [
-                    {
-                        "id": "malware--664fa29d-bf65-4f28-a667-bdb76f29ec98",
-                        "message": "Unable to process object"
-                    }
+                  {
+                    "id": "malware--664fa29d-bf65-4f28-a667-bdb76f29ec98",
+		    "version": "2018-05-28T14:03:42:.543Z",
+                    "message": "Unable to process object"
+                  }
                 ],
                 "pending_count": 2,
                 "pendings": [
-                    "indicator--252c7c11-daf2-42bd-843b-be65edca9f61",
-                    "relationship--045585ad-a22f-4333-af33-bfd503a683b5"
+		  {
+                    "id": "indicator--252c7c11-daf2-42bd-843b-be65edca9f61",
+		    "version": "2018-05-18T20:16:21.148Z"
+		  },
+		  {
+                    "id": "relationship--045585ad-a22f-4333-af33-bfd503a683b5",
+		    "version": "2018-05-15T10:13:32.579Z"
+		  }
                 ]
             },
             {

--- a/medallion/test/data/initialize_mongodb.py
+++ b/medallion/test/data/initialize_mongodb.py
@@ -274,7 +274,7 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
     api_root_db = add_api_root(
         client,
         url="http://localhost:5000/api2/",
-        title="STIX 2.0 Indicator Collections",
+        title="STIX 2.1 Indicator Collections",
         description="A repo for general STIX data.",
         max_content_length=9765625,
     )

--- a/medallion/test/generic_initialize_mongodb.py
+++ b/medallion/test/generic_initialize_mongodb.py
@@ -53,7 +53,7 @@ def add_api_root(client, url=None, title=None, description=None, versions=None, 
 
     """
     if not versions:
-        versions = ["taxii-2.0"]
+        versions = ["taxii-2.1"]
     db = client["discovery_database"]
     url_parts = url.split("/")
     name = url_parts[-2]

--- a/medallion/test/test_memory_backend.py
+++ b/medallion/test/test_memory_backend.py
@@ -102,7 +102,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         collections_metadata = self.load_json_response(r.data)
-        assert collections_metadata["media_types"][0] == "application/vnd.oasis.stix+json; version=2.1"
+        assert collections_metadata["media_types"][0] == "application/taxii+json;version=2.1"
 
     def test_get_collection_not_existent(self):
         r = self.client.get(
@@ -368,7 +368,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         manifests = self.load_json_response(r_get.data)
 
         assert manifests["objects"][0]["id"] == new_id
-        assert any(version == new_bundle["objects"][0]["modified"] for version in manifests["objects"][0]["versions"])
+        assert manifests["objects"][0]["version"] == new_bundle["objects"][0]["modified"]
         # ------------- END: get manifest section ------------- #
 
     def test_added_after_filtering(self):

--- a/medallion/test/test_memory_backend.py
+++ b/medallion/test/test_memory_backend.py
@@ -9,7 +9,7 @@ import six
 
 from medallion import set_config, test
 from medallion.utils import common
-from medallion.views import MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20
+from medallion.views import MEDIA_TYPE_TAXII_V21
 
 from .base_test import TaxiiTest
 
@@ -62,7 +62,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         r = self.client.get(test.DISCOVERY_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         server_info = self.load_json_response(r.data)
         assert server_info["api_roots"][0] == "http://localhost:5000/api1/"
 
@@ -70,7 +70,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         r = self.client.get(test.API_ROOT_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         api_root_metadata = self.load_json_response(r.data)
         assert api_root_metadata["title"] == "Malware Research Group"
 
@@ -83,7 +83,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         r = self.client.get(test.COLLECTIONS_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         collections_metadata = self.load_json_response(r.data)
         collections_metadata = sorted(collections_metadata["collections"], key=lambda x: x["id"])
         collection_ids = [cm["id"] for cm in collections_metadata]
@@ -100,9 +100,9 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         collections_metadata = self.load_json_response(r.data)
-        assert collections_metadata["media_types"][0] == "application/vnd.oasis.stix+json; version=2.0"
+        assert collections_metadata["media_types"][0] == "application/vnd.oasis.stix+json; version=2.1"
 
     def test_get_collection_not_existent(self):
         r = self.client.get(
@@ -118,7 +118,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         obj = self.load_json_response(r.data)
         assert obj["objects"][0]["id"] == "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111"
 
@@ -129,7 +129,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         objs = self.load_json_response(r.data)
         assert any(obj["id"] == "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463" for obj in objs["objects"])
 
@@ -141,8 +141,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -151,20 +151,20 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         )
         status_response = self.load_json_response(r_post.data)
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- END: add object section ------------- #
         # ------------- BEGIN: get object section ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s" % new_id,
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -177,7 +177,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         status_response2 = self.load_json_response(r_get.data)
         assert status_response2["success_count"] == 1
@@ -190,7 +190,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
         assert manifests["objects"][0]["id"] == new_id
@@ -204,8 +204,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -213,7 +213,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=post_header,
         )
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- END: add object section ------------- #
         # ------------- BEGIN: add object again section ------------- #
@@ -235,7 +235,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         # ------------- BEGIN: get object section ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s" % new_id,
@@ -254,8 +254,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -264,7 +264,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         )
         status_response = self.load_json_response(r_post.data)
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         for i in range(0, 5):
             new_bundle = copy.deepcopy(self.API_OBJECTS_2)
@@ -277,13 +277,13 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             )
             status_response = self.load_json_response(r_post.data)
             self.assertEqual(r_post.status_code, 202)
-            self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+            self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- END: add object section ------------- #
         # ------------- BEGIN: get object section 1 ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s&match[version]=%s"
@@ -291,7 +291,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -306,7 +306,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -321,7 +321,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -336,7 +336,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -350,7 +350,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         status_response2 = self.load_json_response(r_get.data)
         assert status_response2["success_count"] == 1
@@ -363,7 +363,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -373,14 +373,14 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
 
     def test_added_after_filtering(self):
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?added_after=2016-11-01T03:04:05Z",
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
         bundle = self.load_json_response(r_get.data)
 
         assert any(obj["id"] == "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111" for obj in bundle["objects"])
@@ -391,8 +391,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         with tempfile.NamedTemporaryFile() as f:
             self.client.post(
@@ -499,8 +499,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = {}
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -527,8 +527,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.FORBIDDEN_COLLECTION_EP + "objects/",
@@ -551,8 +551,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.NON_EXISTENT_COLLECTION_EP + "objects/",
@@ -581,8 +581,8 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
         }
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -590,7 +590,7 @@ class TestTAXIIServerWithMemoryBackend(TaxiiTest):
             headers=post_header,
         )
         self.assertEqual(r_post.status_code, 422)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
         error_data = self.load_json_response(r_post.data)
         assert error_data["title"] == "ProcessingError"
         assert error_data["http_status"] == "422"

--- a/medallion/test/test_mongodb_backend.py
+++ b/medallion/test/test_mongodb_backend.py
@@ -7,7 +7,7 @@ import six
 from medallion import test
 from medallion.test.generic_initialize_mongodb import connect_to_client
 from medallion.utils import common
-from medallion.views import MEDIA_TYPE_STIX_V21, MEDIA_TYPE_TAXII_V21
+from medallion.views import MEDIA_TYPE_TAXII_V21
 
 from .base_test import TaxiiTest
 
@@ -84,7 +84,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         obj = self.load_json_response(r.data)
         assert obj["objects"][0]["id"] == "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111"
 
@@ -95,7 +95,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         objs = self.load_json_response(r.data)
         assert any(obj["id"] == "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463" for obj in objs["objects"])
 
@@ -106,7 +106,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         objs = self.load_json_response(r.data)
 
         # there should be only two indicators in this collection
@@ -124,7 +124,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -140,14 +140,14 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: get object section ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V21
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s" % new_id,
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -187,7 +187,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -216,7 +216,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: get object section 1 ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V21
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s&match[version]=%s"
@@ -224,7 +224,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -239,7 +239,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -254,7 +254,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -269,7 +269,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -306,7 +306,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
 
     def test_added_after_filtering(self):
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V21
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         # ------------- BEGIN: test with static data section ------------- #
 
@@ -315,7 +315,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
         bundle = self.load_json_response(r_get.data)
 
         # none of the objects in the test data set has an added_after date post 1 Jan 2018
@@ -328,7 +328,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -346,7 +346,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
         bundle = self.load_json_response(r_get.data)
 
         self.assertEqual(1, len(bundle['objects']))
@@ -354,7 +354,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
 
     def test_marking_defintions(self):
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V21
+        get_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         # ------------- BEGIN: get manifest section 1 ------------- #
         r_get = self.client.get(
@@ -388,7 +388,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -401,7 +401,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -414,7 +414,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -427,7 +427,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -519,8 +519,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = {}
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
-        post_header["Accept"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -547,7 +547,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -571,7 +571,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -601,7 +601,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         }
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -634,7 +634,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["external_references"] = external_references
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -660,7 +660,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -691,7 +691,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         objs = self.load_json_response(r.data)
 
         # there should be only one indicator in this collection
@@ -710,7 +710,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             bundle['objects'].append(obj)
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
@@ -801,7 +801,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             bundle['objects'].append(obj)
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Content-Type"] = MEDIA_TYPE_TAXII_V21
         post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(

--- a/medallion/test/test_mongodb_backend.py
+++ b/medallion/test/test_mongodb_backend.py
@@ -7,7 +7,7 @@ import six
 from medallion import test
 from medallion.test.generic_initialize_mongodb import connect_to_client
 from medallion.utils import common
-from medallion.views import MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20
+from medallion.views import MEDIA_TYPE_STIX_V21, MEDIA_TYPE_TAXII_V21
 
 from .base_test import TaxiiTest
 
@@ -26,7 +26,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         r = self.client.get(test.DISCOVERY_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         server_info = self.load_json_response(r.data)
         assert server_info["title"] == "Some TAXII Server"
         assert len(server_info["api_roots"]) == 2
@@ -36,7 +36,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         r = self.client.get(test.API_ROOT_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         api_root_metadata = self.load_json_response(r.data)
         assert api_root_metadata["title"] == "Malware Research Group"
 
@@ -48,7 +48,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         r = self.client.get(test.COLLECTIONS_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         collections_metadata = self.load_json_response(r.data)
         collections_metadata = sorted(collections_metadata["collections"], key=lambda x: x["id"])
         collection_ids = [cm["id"] for cm in collections_metadata]
@@ -66,9 +66,9 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         collections_metadata = self.load_json_response(r.data)
-        assert collections_metadata["media_types"][0] == "application/vnd.oasis.stix+json; version=2.0"
+        assert collections_metadata["media_types"][0] == "application/vnd.oasis.stix+json; version=2.1"
 
     def test_get_collection_not_existent(self):
         r = self.client.get(
@@ -84,7 +84,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         obj = self.load_json_response(r.data)
         assert obj["objects"][0]["id"] == "malware--fdd60b30-b67c-11e3-b0b9-f01faf20d111"
 
@@ -95,7 +95,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         objs = self.load_json_response(r.data)
         assert any(obj["id"] == "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463" for obj in objs["objects"])
 
@@ -106,7 +106,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         objs = self.load_json_response(r.data)
 
         # there should be only two indicators in this collection
@@ -124,8 +124,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -134,20 +134,20 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
         status_response = self.load_json_response(r_post.data)
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- END: add object section ------------- #
         # ------------- BEGIN: get object section ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_STIX_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s" % new_id,
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -160,7 +160,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         status_response2 = self.load_json_response(r_get.data)
         assert status_response2["success_count"] == 1
@@ -173,7 +173,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
         assert manifests["objects"][0]["id"] == new_id
@@ -187,8 +187,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         # ------------- BEGIN: add object section ------------- #
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -197,7 +197,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
         status_response = self.load_json_response(r_post.data)
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         for i in range(0, 5):
             new_bundle = copy.deepcopy(self.API_OBJECTS_2)
@@ -210,13 +210,13 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             )
             status_response = self.load_json_response(r_post.data)
             self.assertEqual(r_post.status_code, 202)
-            self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+            self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- END: add object section ------------- #
         # ------------- BEGIN: get object section 1 ------------- #
 
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_STIX_V21
 
         r_get = self.client.get(
             test.GET_OBJECTS_EP + "?match[id]=%s&match[version]=%s"
@@ -224,7 +224,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -239,7 +239,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -254,7 +254,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -269,7 +269,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         objs = self.load_json_response(r_get.data)
         assert objs["objects"][0]["id"] == new_id
@@ -283,7 +283,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         status_response2 = self.load_json_response(r_get.data)
         assert status_response2["success_count"] == 1
@@ -296,7 +296,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=self.auth,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -306,7 +306,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
 
     def test_added_after_filtering(self):
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_STIX_V21
 
         # ------------- BEGIN: test with static data section ------------- #
 
@@ -315,7 +315,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
         bundle = self.load_json_response(r_get.data)
 
         # none of the objects in the test data set has an added_after date post 1 Jan 2018
@@ -328,8 +328,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -338,7 +338,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
         self.load_json_response(r_post.data)
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # refetch objects post 1 Jan 2018 - should now have 1 result
         r_get = self.client.get(
@@ -346,7 +346,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
         bundle = self.load_json_response(r_get.data)
 
         self.assertEqual(1, len(bundle['objects']))
@@ -354,7 +354,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
 
     def test_marking_defintions(self):
         get_header = copy.deepcopy(self.auth)
-        get_header["Accept"] = MEDIA_TYPE_STIX_V20
+        get_header["Accept"] = MEDIA_TYPE_STIX_V21
 
         # ------------- BEGIN: get manifest section 1 ------------- #
         r_get = self.client.get(
@@ -362,7 +362,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -375,7 +375,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_TAXII_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -388,7 +388,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -401,7 +401,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -414,7 +414,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -427,7 +427,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             headers=get_header,
         )
         self.assertEqual(r_get.status_code, 200)
-        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r_get.content_type, MEDIA_TYPE_STIX_V21)
 
         manifests = self.load_json_response(r_get.data)
 
@@ -519,8 +519,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = {}
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_STIX_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_STIX_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -547,8 +547,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.FORBIDDEN_COLLECTION_EP + "objects/",
@@ -571,8 +571,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.NON_EXISTENT_COLLECTION_EP + "objects/",
@@ -601,8 +601,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         }
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -611,7 +611,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 422)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
         error_data = self.load_json_response(r_post.data)
         assert error_data["title"] == "ProcessingError"
         assert error_data["http_status"] == "422"
@@ -634,8 +634,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["external_references"] = external_references
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -644,7 +644,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # get the indicator and check the valid_until date and external_references are returned
         r = self.client.get(test.GET_OBJECT_EP + new_id + '/', headers=self.auth)
@@ -660,8 +660,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         new_bundle["objects"][0]["id"] = new_id
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -670,7 +670,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # now also add that identical object to another collection
         r_post = self.client.post(
@@ -680,7 +680,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- BEGIN: test that all returned objects belong to the correct collection ------------- #
         # now query for that object in one collection and confirm we don't recieve both
@@ -691,7 +691,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         objs = self.load_json_response(r.data)
 
         # there should be only one indicator in this collection
@@ -710,8 +710,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             bundle['objects'].append(obj)
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -720,7 +720,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- BEGIN: test request for subset of objects endpoint ------------- #
 
@@ -801,8 +801,8 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
             bundle['objects'].append(obj)
 
         post_header = copy.deepcopy(self.auth)
-        post_header["Content-Type"] = MEDIA_TYPE_STIX_V20
-        post_header["Accept"] = MEDIA_TYPE_TAXII_V20
+        post_header["Content-Type"] = MEDIA_TYPE_STIX_V21
+        post_header["Accept"] = MEDIA_TYPE_TAXII_V21
 
         r_post = self.client.post(
             test.ADD_OBJECTS_EP,
@@ -811,7 +811,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
         )
 
         self.assertEqual(r_post.status_code, 202)
-        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r_post.content_type, MEDIA_TYPE_TAXII_V21)
 
         # ------------- BEGIN: test request for subset of manifests endpoint------------- #
 
@@ -868,7 +868,7 @@ class TestTAXIIServerWithMongoDBBackend(TaxiiTest):
                 "can_read": True,
                 "can_write": True,
                 "media_types": [
-                    "application/vnd.oasis.stix+json; version=2.0",
+                    "application/vnd.oasis.stix+json; version=2.1",
                 ],
             }
             collections.append(col)

--- a/medallion/test/test_views.py
+++ b/medallion/test/test_views.py
@@ -9,7 +9,7 @@ import six
 
 from medallion import (application_instance, register_blueprints, set_config,
                        test)
-from medallion.views import MEDIA_TYPE_STIX_V20, MEDIA_TYPE_TAXII_V20
+from medallion.views import MEDIA_TYPE_STIX_V21, MEDIA_TYPE_TAXII_V21
 
 if sys.version_info < (3, 3, 0):
     import mock
@@ -20,7 +20,7 @@ BUNDLE = {
     "id": "bundle--8fab937e-b694-11e3-b71c-0800271e87d2",
     "objects": [
     ],
-    "spec_version": "2.0",
+    "spec_version": "2.1",
     "type": "bundle",
 }
 
@@ -88,7 +88,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         r = self.client.get(test.COLLECTIONS_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test collection endpoint ------------- #
@@ -100,7 +100,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test manifests endpoint ------------- #
@@ -112,7 +112,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test objects endpoint ------------- #
@@ -139,7 +139,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         r = self.client.get(test.GET_OBJECT_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test small result set ------------- #
@@ -157,7 +157,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         objs = self.load_json_response(r.data)
 
         self.assertEqual(r.status_code, 206)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V20)
+        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
         self.assertIsNotNone(r.headers.get('Content-Range', None))
         self.assertEqual(r.headers.get('Content-Range'), 'items 0-{}/100'.format(page_size - 1))

--- a/medallion/test/test_views.py
+++ b/medallion/test/test_views.py
@@ -9,7 +9,7 @@ import six
 
 from medallion import (application_instance, register_blueprints, set_config,
                        test)
-from medallion.views import MEDIA_TYPE_STIX_V21, MEDIA_TYPE_TAXII_V21
+from medallion.views import MEDIA_TYPE_TAXII_V21
 
 if sys.version_info < (3, 3, 0):
     import mock
@@ -112,7 +112,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         )
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test objects endpoint ------------- #
@@ -139,7 +139,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         r = self.client.get(test.GET_OBJECT_EP, headers=self.auth)
 
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
 
         # ------------- END: test small result set ------------- #
@@ -157,7 +157,7 @@ class TestTAXIIServerWithMockBackend(unittest.TestCase):
         objs = self.load_json_response(r.data)
 
         self.assertEqual(r.status_code, 206)
-        self.assertEqual(r.content_type, MEDIA_TYPE_STIX_V21)
+        self.assertEqual(r.content_type, MEDIA_TYPE_TAXII_V21)
         self.assertIsNotNone(r.headers.get('Accept-Ranges', None))
         self.assertIsNotNone(r.headers.get('Content-Range', None))
         self.assertEqual(r.headers.get('Content-Range'), 'items 0-{}/100'.format(page_size - 1))

--- a/medallion/utils/common.py
+++ b/medallion/utils/common.py
@@ -5,7 +5,7 @@ import pytz
 from six import iteritems, text_type
 
 
-def generate_stix20_id(sdo_type):
+def generate_stix21_id(sdo_type):
     return "{sdo_type}--{uuid}".format(
         sdo_type=sdo_type,
         uuid=text_type(uuid.uuid4()),
@@ -14,9 +14,9 @@ def generate_stix20_id(sdo_type):
 
 def create_bundle(o):
     return {
-        "id": generate_stix20_id("bundle"),
+        "id": generate_stix21_id("bundle"),
         "objects": o,
-        "spec_version": "2.0",
+        "spec_version": "2.1",
         "type": "bundle",
     }
 

--- a/medallion/views/manifest.py
+++ b/medallion/views/manifest.py
@@ -3,7 +3,7 @@ from flask import Blueprint, Response, current_app, json, request
 from . import MEDIA_TYPE_TAXII_V21
 from .. import auth
 from ..exceptions import ProcessingError
-from .objects import (collection_exists, get_custom_headers, permission_to_read)
+from .objects import collection_exists, get_custom_headers, permission_to_read
 
 mod = Blueprint("manifest", __name__)
 


### PR DESCRIPTION
Modified the TAXII filter to be up to spec for 2.1. Also changed the default_data to be representative of data expected on a 2.1 server, and changed some small things in the memory_backend to try to make the tests run. 