### PR TITLE
Fix typo in data_for_memory_config.json

### DIFF
--- a/example_configs/data_for_memory_config.json
+++ b/example_configs/data_for_memory_config.json
@@ -19,8 +19,8 @@
       ],
       "max_content_length": 9765625
     },
-    "status": {
-    },
+    "status": [
+    ],
     "collections": [
     ]
   },


### PR DESCRIPTION
"status" field accepts `list` type rather `dict`.