### PR TITLE
MongoDB document architecture change

### DIFF
--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -7,9 +7,9 @@ from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from ..common import (
     SessionChecker, create_resource, datetime_to_float, datetime_to_string,
     datetime_to_string_stix, determine_spec_version, determine_version,
-    find_version_attribute, float_to_datetime, generate_status,
-    generate_status_details, get_custom_headers, get_timestamp,
-    parse_request_parameters, string_to_datetime
+    float_to_datetime, generate_status, generate_status_details,
+    get_custom_headers, get_timestamp, parse_request_parameters,
+    string_to_datetime
 )
 from ..exceptions import MongoBackendError, ProcessingError
 from ..filters.mongodb_filter import MongoDBFilter

--- a/medallion/filters/mongodb_filter.py
+++ b/medallion/filters/mongodb_filter.py
@@ -52,7 +52,6 @@ class MongoDBFilter(BasicFilter):
     def process_filter(self, data, allowed, manifest_info):
         pipeline = [
             {"$match": {"$and": [self.full_query]}},
-            {"$sort": {"_manifest.media_type": pymongo.ASCENDING, "_manifest.version": pymongo.ASCENDING}},
         ]
 
         latest_pipeline = []
@@ -63,6 +62,7 @@ class MongoDBFilter(BasicFilter):
         if not match_spec_version and "spec_version" in allowed:
             latest_op = {"$group": {"_id": "$id", "media_type": {"$last": "$_manifest.media_type"}}}
             latest_pipeline = list(pipeline)
+            latest_pipeline.append({"$sort": {"_manifest.media_type": pymongo.ASCENDING}})
             latest_pipeline.append(latest_op)
 
         if "media_type" in latest_op.get("$group", {}):
@@ -82,6 +82,7 @@ class MongoDBFilter(BasicFilter):
                 actual_dates = [datetime_to_float(string_to_datetime(x)) for x in match_version.split(",") if (x != "first" and x != "last")]
                 latest_op = {"$group": {"_id": "$id", "versions": {"$push": "$_manifest.version"}}}
                 latest_pipeline = list(pipeline)
+                latest_pipeline.append({"$sort": {"_manifest.version": pymongo.ASCENDING}})
                 latest_pipeline.append(latest_op)
 
                 # The documents are sorted in ASCENDING order.

--- a/medallion/filters/mongodb_filter.py
+++ b/medallion/filters/mongodb_filter.py
@@ -19,9 +19,9 @@ class MongoDBFilter(BasicFilter):
             if match_type and "type" in allowed:
                 types_ = match_type.split(",")
                 if len(types_) == 1:
-                    parameters["_type"] = {"$eq": types_[0]}
+                    parameters["type"] = {"$eq": types_[0]}
                 else:
-                    parameters["_type"] = {"$in": types_}
+                    parameters["type"] = {"$in": types_}
             match_id = self.filter_args.get("match[id]")
             if match_id and "id" in allowed:
                 ids_ = match_id.split(",")
@@ -29,55 +29,49 @@ class MongoDBFilter(BasicFilter):
                     parameters["id"] = {"$eq": ids_[0]}
                 else:
                     parameters["id"] = {"$in": ids_}
-        return parameters
-
-    def process_filter(self, data, allowed, manifest_info):
-        match_filter = {
-            "$match": {
-                "$and": [self.full_query],
-                "$comment": "Step #1: Match against an object/manifest id or type present in a collection.",
-            },
-        }
-        pipeline = [match_filter]
-
-        # create added_after filter
-        added_after_date = self.filter_args.get("added_after")
-        if added_after_date:
-            added_after_timestamp = datetime_to_float(string_to_datetime(added_after_date))
-            date_filter = {
-                "$match": {
-                    "date_added": {"$gt": added_after_timestamp},
-                    "$comment": "Step #2: If added_after is provided, remove all objects/manifests older than the provided time",
-                }
-            }
-            pipeline.append(date_filter)
-
-        # create spec_version filter. when no filter is provided only latest is considered.
-        if "spec_version" in allowed:
             match_spec_version = self.filter_args.get("match[spec_version]")
-            if match_spec_version:
+            if match_spec_version and "spec_version" in allowed:
                 spec_versions = match_spec_version.split(",")
                 media_fmt = "application/stix+json;version={}"
                 if len(spec_versions) == 1:
-                    pipeline[0]["$match"]["$and"].append({"media_type": {"$eq": media_fmt.format(spec_versions[0])}})
-                else:
-                    pipeline[0]["$match"]["$and"].append({"media_type": {"$in": [media_fmt.format(x) for x in spec_versions]}})
-            else:
-                pipeline.append({"$group": {"_id": "$id", "objs": {"$push": "$$ROOT"}, "media_types": {"$push": "$media_type"}}})
-                pipeline.append({"$sort": {"media_types": pymongo.ASCENDING}})
-                pipeline.append({"$addFields": {"media_types": {"$arrayElemAt": ["$media_types", -1]}}})
-                redact_objects = {
-                    "$redact": {
-                        "$cond": {
-                            "if": {"$ne": ["$objs.media_type", "$media_types"]},
-                            "then": "$$KEEP",
-                            "else": "$$PRUNE",
-                        }
+                    parameters["_manifest.media_type"] = {
+                        "$eq": media_fmt.format(spec_versions[0])
                     }
+                else:
+                    parameters["_manifest.media_type"] = {
+                        "$in": [media_fmt.format(x) for x in spec_versions]
+                    }
+            added_after_date = self.filter_args.get("added_after")
+            if added_after_date:
+                added_after_timestamp = datetime_to_float(string_to_datetime(added_after_date))
+                parameters["_manifest.date_added"] = {
+                    "$gt": added_after_timestamp,
                 }
-                pipeline.append(redact_objects)
-                pipeline.append({"$unwind": "$objs"})
-                pipeline.append({"$replaceRoot": {"newRoot": "$objs"}})
+        return parameters
+
+    def process_filter(self, data, allowed, manifest_info):
+        pipeline = [
+            {"$match": {"$and": [self.full_query]}},
+            {"$sort": {"_manifest.media_type": pymongo.ASCENDING, "_manifest.version": pymongo.ASCENDING}},
+        ]
+
+        latest_pipeline = []
+        latest_op = {}
+
+        # when no filter is provided only latest is considered.
+        match_spec_version = self.filter_args.get("match[spec_version]")
+        if not match_spec_version and "spec_version" in allowed:
+            latest_op = {"$group": {"_id": "$id", "media_type": {"$last": "$_manifest.media_type"}}}
+            latest_pipeline = list(pipeline)
+            latest_pipeline.append(latest_op)
+
+        if "media_type" in latest_op.get("$group", {}):
+            query = [
+                {"id": x["_id"], "_manifest.media_type": x["media_type"]}
+                for x in list(data.aggregate(latest_pipeline))
+            ]
+            if query:
+                pipeline.append({"$match": {"$or": query}})
 
         # create version filter
         if "version" in allowed:
@@ -86,18 +80,11 @@ class MongoDBFilter(BasicFilter):
                 match_version = "last"
             if "all" not in match_version:
                 actual_dates = [datetime_to_float(string_to_datetime(x)) for x in match_version.split(",") if (x != "first" and x != "last")]
-                # If specific dates have been selected, then we add these to the $match criteria
-                # created from the self.full_query at the beginning of this method. This will make
-                # sure we can pick the correct manifests even if `added_after` later modifies this results.
-                if len(actual_dates) > 0:
-                    pipeline[0]["$match"]["$and"].append({"version": {"$in": actual_dates}})
+                latest_op = {"$group": {"_id": "$id", "versions": {"$push": "$_manifest.version"}}}
+                latest_pipeline = list(pipeline)
+                latest_pipeline.append(latest_op)
 
-                pipeline.append({"$sort": {"version": pymongo.ASCENDING}})
-                pipeline.append({"$group": {"_id": "$id", "versions": {"$push": "$$ROOT"}}})
-
-                # The versions array in the mongodb document is ordered oldest to newest, so the 'last'
-                # (most recent date) is in last position in the list and the oldest 'first' is in
-                # the first position.
+                # The documents are sorted in ASCENDING order.
                 version_selector = []
                 if "last" in match_version:
                     version_selector.append({"$arrayElemAt": ["$versions", -1]})
@@ -105,110 +92,40 @@ class MongoDBFilter(BasicFilter):
                     version_selector.append({"$arrayElemAt": ["$versions", 0]})
                 for d in actual_dates:
                     version_selector.append({"$arrayElemAt": ["$versions", {"$indexOfArray": ["$versions", d]}]})
-                pipeline.append({"$addFields": {"versions": version_selector}})
+                latest_pipeline.append({"$addFields": {"versions": version_selector}})
+                if actual_dates:
+                    latest_pipeline.append({"$match": {"versions": {"$in": actual_dates}}})
 
-                # denormalize the embedded objects, remove duplicates and replace the document root. Could be improved
-                pipeline.append({"$unwind": "$versions"})
-                pipeline.append({"$replaceRoot": {"newRoot": "$versions"}})
-                pipeline.append({"$group": {"_id": "$$ROOT"}})
-                pipeline.append({"$replaceRoot": {"newRoot": "$_id"}})
-        pipeline.append({"$sort": {"date_added": pymongo.ASCENDING}})
+        if "versions" in latest_op.get("$group", {}):
+            query = [
+                {"id": x["_id"], "_manifest.version": {"$in": x["versions"]}}
+                for x in list(data.aggregate(latest_pipeline))
+            ]
+            if query:
+                pipeline.append({"$match": {"$or": query}})
 
-        if data.name == "manifests":
+        pipeline.append({"$sort": {"_manifest.date_added": pymongo.ASCENDING, "created": pymongo.ASCENDING, "modified": pymongo.ASCENDING}})
+
+        if manifest_info == "manifests":
             # Project the final results
-            project_results = {"$project": {"_id": 0, "_collection_id": 0, "_type": 0}}
-            pipeline.append(project_results)
+            pipeline.append({"$project": {"_manifest": 1}})
+            pipeline.append({"$replaceRoot": {"newRoot": "$_manifest"}})
 
             count = self.get_result_count(pipeline, data)
             self.add_pagination_operations(pipeline)
-            cursor = data.aggregate(pipeline)
-            results = list(cursor)
-        else:
-            # Join the filtered manifest(s) to the objects collection
-            join_objects = {
-                "$lookup": {
-                    "from": "objects",
-                    "localField": "id",
-                    "foreignField": "id",
-                    "as": "obj",
-                },
-            }
-            pipeline.append(join_objects)
-
-            # Copy the filtered version list to the embedded object document
-            add_versions = {
-                "$addFields": {"obj.version": "$version"},
-            }
-            pipeline.append(add_versions)
-
-            # Copy the media_type we a looking for into the embedded object document
-            add_media_type = {
-                "$addFields": {"obj.media_type": "$media_type"},
-            }
-            pipeline.append(add_media_type)
-
-            # denormalize the embedded objects and replace the document root
-            pipeline.append({"$unwind": "$obj"})
-            pipeline.append({"$replaceRoot": {"newRoot": "$obj"}})
-
-            # Redact the result set removing objects where the modified date is not in
-            # the version field and the object isn't in the correct collection.
-            # The collection filter is required because the join between manifests and objects
-            # does not include collection_id.
-            #
-            col_id = self.full_query["_collection_id"]["$eq"]
-            redact_objects = {
-                "$redact": {
-                    "$cond": {
-                        "if": {
-                            "$and": [
-                                {"$eq": ["$_collection_id", col_id]},
-                                {
-                                    "$switch": {
-                                        "branches": [
-                                            {"case": {"$eq": ["$modified", "$version"]}, "then": True},
-                                            {"case": {"$and": [
-                                                {"$eq": ["$created", "$version"]}, {"$not": ["$modified"]}
-                                            ]}, "then": True},
-                                            {"case": {"$eq": ["$_date_added", "$version"]}, "then": True},
-                                        ],
-                                        "default": False,
-                                    },
-                                },
-                                {
-                                    "$switch": {
-                                        "branches": [
-                                            {"case": {"$eq": ["$spec_version", {"$substrBytes": ["$media_type", 30, 4]}]}, "then": True},
-                                            {"case": {"$and": [
-                                                {"$eq": ["2.0", {"$substrBytes": ["$media_type", 30, 4]}]}, {"$not": ["$spec_version"]}
-                                            ]}, "then": True},
-                                        ],
-                                        "default": False,
-                                    },
-                                }
-                            ],
-                        },
-                        "then": "$$KEEP",
-                        "else": "$$PRUNE",
-                    },
-                },
-            }
-            pipeline.append(redact_objects)
-
-            # denormalize the embedded objects, remove duplicates and replace the document root. Could be improved
-            pipeline.append({"$group": {"_id": "$$ROOT"}})
-            pipeline.append({"$replaceRoot": {"newRoot": "$_id"}})
-            pipeline.append({"$sort": {"_date_added": pymongo.ASCENDING, "created": pymongo.ASCENDING, "modified": pymongo.ASCENDING}})
-
+            results = list(data.aggregate(pipeline))
+        elif manifest_info == "objects":
             # Project the final results
-            project_results = {"$project": {"version": 0, "media_type": 0, "_id": 0, "_collection_id": 0, "_date_added": 0}}
-            pipeline.append(project_results)
+            pipeline.append({"$project": {"_id": 0, "_collection_id": 0, "_manifest": 0}})
 
-            count = self.get_result_count(pipeline, manifest_info)
+            count = self.get_result_count(pipeline, data)
             self.add_pagination_operations(pipeline)
-
-            cursor = manifest_info.aggregate(pipeline)
-            results = list(cursor)
+            results = list(data.aggregate(pipeline))
+        else:
+            # Return raw data from Mongodb
+            count = self.get_result_count(pipeline, data)
+            self.add_pagination_operations(pipeline)
+            results = list(data.aggregate(pipeline))
 
         return count, results
 

--- a/medallion/test/data/default_data.json
+++ b/medallion/test/data/default_data.json
@@ -203,7 +203,7 @@
                         "spec_version": "2.1",
                         "type": "marking-definition"
                     },
-		    {
+                    {
                         "created": "2017-01-27T13:49:53.997Z",
                         "description": "Poison Ivy",
                         "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
@@ -266,7 +266,7 @@
                         "media_type": "application/stix+json;version=2.1",
                         "version": "2017-01-27T13:49:53.997Z"
                     },
-		    {
+                    {
                         "date_added": "2017-01-27T13:49:59.997000Z",
                         "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
                         "media_type": "application/stix+json;version=2.0",

--- a/medallion/test/data/initialize_mongodb.py
+++ b/medallion/test/data/initialize_mongodb.py
@@ -94,65 +94,6 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
         },
     ])
 
-    api_root_db["manifests"].insert_many([
-        {
-            "date_added": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000000Z")),
-            "id": "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "relationship",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2016-11-01T03:04:05.000000Z")),
-            "id": "indicator--cd981c25-8042-4166-8945-51178443bdac",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "indicator",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.001000Z")),
-            "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
-            "media_type": "application/stix+json;version=2.0",
-            "version": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "indicator",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2016-12-27T13:49:59.000000Z")),
-            "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2016-12-25T12:30:59.444Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "indicator",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2017-01-20T00:00:00.000000Z")),
-            "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2017-01-20T00:00:00.000Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "marking-definition",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2017-01-27T13:49:59.997000Z")),
-            "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.997Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "malware",
-        },
-        {
-            "date_added": datetime_to_float(string_to_datetime("2017-12-31T13:49:53.935000Z")),
-            "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
-            "media_type": "application/stix+json;version=2.1",
-            "version": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.935Z")),
-            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
-            "_type": "indicator",
-        }
-    ])
-
     api_root_db["collections"].insert_one({
         "id": "472c94ae-3113-4e3e-a4dd-a9f4ac7471d4",
         "title": "This data collection is for testing querying across collections",
@@ -180,6 +121,7 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
         "can_read": True,
         "can_write": True,
         "media_types": [
+            "application/stix+json;version=2.0",
             "application/stix+json;version=2.1",
         ],
     })
@@ -217,6 +159,12 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "target_ref": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
             "type": "relationship",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000000Z")),
+                "id": "relationship--2f9a9aa9-108a-4333-83e2-4fb25add0463",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000Z")),
@@ -232,6 +180,12 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "type": "indicator",
             "valid_from": "2014-05-08T09:00:00.000000Z",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2016-11-01T03:04:05.000000Z")),
+                "id": "indicator--cd981c25-8042-4166-8945-51178443bdac",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2014-05-08T09:00:00.000Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
@@ -244,10 +198,15 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "name": "Malicious site hosting downloader",
             "pattern": "[url:value = 'http://z4z10farb.cn/4712']",
             "pattern_type": "stix",
-            "spec_version": "2.0",
             "type": "indicator",
             "valid_from": "2017-01-27T13:49:53.935382Z",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.001000Z")),
+                "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
+                "media_type": "application/stix+json;version=2.0",
+                "version": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
@@ -264,6 +223,12 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "type": "indicator",
             "valid_from": "2017-01-27T13:49:53.935382Z",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2016-12-27T13:49:59.000000Z")),
+                "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2016-12-25T12:30:59.444Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
@@ -280,6 +245,12 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "type": "indicator",
             "valid_from": "2016-11-03T12:30:59.000Z",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2017-12-31T13:49:53.935000Z")),
+                "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.935Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2017-01-20T00:00:00.000Z")),
@@ -292,6 +263,12 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "spec_version": "2.1",
             "type": "marking-definition",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2017-01-20T00:00:00.000000Z")),
+                "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2017-01-20T00:00:00.000Z")),
+            },
         },
         {
             "created": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.997Z")),
@@ -306,18 +283,27 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "spec_version": "2.1",
             "type": "malware",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2017-01-27T13:49:59.997000Z")),
+                "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
+                "media_type": "application/stix+json;version=2.1",
+                "version": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.997Z")),
+            },
         }
     ])
 
-    date_index = IndexModel([("date_added", ASCENDING)])
     id_index = IndexModel([("id", ASCENDING)])
+    type_index = IndexModel([("type", ASCENDING)])
     collection_index = IndexModel([("_collection_id", ASCENDING)])
-    collection_and_date_index = IndexModel([("_collection_id", ASCENDING), ("date_added", ASCENDING)])
-    type_index = IndexModel([("_type", ASCENDING)])
-    api_root_db["manifests"].create_indexes(
-        [date_index, id_index, collection_index, collection_and_date_index, type_index],
+    date_index = IndexModel([("_manifest.date_added", ASCENDING)])
+    version_index = IndexModel([("_manifest.version", ASCENDING)])
+    date_and_spec_index = IndexModel([("_manifest.media_type", ASCENDING), ("_manifest.date_added", ASCENDING)])
+    version_and_spec_index = IndexModel([("_manifest.media_type", ASCENDING), ("_manifest.version", ASCENDING)])
+    collection_and_date_index = IndexModel([("_collection_id", ASCENDING), ("_manifest.date_added", ASCENDING)])
+    api_root_db["objects"].create_indexes(
+        [id_index, type_index, date_index, version_index, collection_index, date_and_spec_index,
+         version_and_spec_index, collection_and_date_index]
     )
-    api_root_db["objects"].create_indexes([id_index])
 
 
 def wipe_mongodb_server():

--- a/medallion/test/data/initialize_mongodb.py
+++ b/medallion/test/data/initialize_mongodb.py
@@ -198,13 +198,14 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "name": "Malicious site hosting downloader",
             "pattern": "[url:value = 'http://z4z10farb.cn/4712']",
             "pattern_type": "stix",
+            "spec_version": "2.1",
             "type": "indicator",
             "valid_from": "2017-01-27T13:49:53.935382Z",
             "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
             "_manifest": {
                 "date_added": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.001000Z")),
                 "id": "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e",
-                "media_type": "application/stix+json;version=2.0",
+                "media_type": "application/stix+json;version=2.1",
                 "version": datetime_to_float(string_to_datetime("2016-11-03T12:30:59.000Z")),
             },
         },
@@ -289,7 +290,26 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
                 "media_type": "application/stix+json;version=2.1",
                 "version": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.997Z")),
             },
-        }
+        },
+        {
+            "created": datetime_to_float(string_to_datetime("2017-01-27T13:49:53.997Z")),
+            "description": "Poison Ivy",
+            "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
+            "is_family": True,
+            "malware_types": [
+                "remote-access-trojan"
+            ],
+            "modified": datetime_to_float(string_to_datetime("2018-02-23T18:30:00.000Z")),
+            "name": "Poison Ivy",
+            "type": "malware",
+            "_collection_id": "91a7b528-80eb-42ed-a74d-c6fbd5a26116",
+            "_manifest": {
+                "date_added": datetime_to_float(string_to_datetime("2017-01-27T13:49:59.997000Z")),
+                "id": "malware--c0931cc6-c75e-47e5-9036-78fabc95d4ec",
+                "media_type": "application/stix+json;version=2.0",
+                "version": datetime_to_float(string_to_datetime("2018-02-23T18:30:00.000Z")),
+            },
+        },
     ])
 
     id_index = IndexModel([("id", ASCENDING)])

--- a/medallion/test/test_backends.py
+++ b/medallion/test/test_backends.py
@@ -442,7 +442,7 @@ def test_get_object_limit(backend):
     assert len(objs['objects']) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all&limit=2",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all&limit=2",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -454,7 +454,7 @@ def test_get_object_limit(backend):
     assert len(objs['objects']) == 2
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all&limit=2&next=" + objs['next'],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all&limit=2&next=" + objs['next'],
         headers=backend.headers,
         follow_redirects=True
     )
@@ -468,7 +468,7 @@ def test_get_object_limit(backend):
 
 def test_get_object_version(backend):
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=2016-12-25T12:30:59.444Z",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=2016-12-25T12:30:59.444Z",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -482,7 +482,7 @@ def test_get_object_version(backend):
     assert objs["objects"][0]["modified"] == "2016-12-25T12:30:59.444Z"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=first",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=first",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -510,7 +510,7 @@ def test_get_object_version(backend):
     assert objs["objects"][0]["id"] == "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -805,7 +805,7 @@ def test_get_version_added_after(backend):
 def test_get_version_limit(backend):
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1",
         headers=backend.headers,
         follow_redirects=True,
     )
@@ -817,7 +817,7 @@ def test_get_version_limit(backend):
     assert len(objs["versions"]) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1&next=" + objs["next"],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1&next=" + objs["next"],
         headers=backend.headers,
         follow_redirects=True,
     )
@@ -829,7 +829,7 @@ def test_get_version_limit(backend):
     assert len(objs["versions"]) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1&next=" + objs["next"],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1&next=" + objs["next"],
         headers=backend.headers,
         follow_redirects=True,
     )

--- a/medallion/test/test_backends.py
+++ b/medallion/test/test_backends.py
@@ -308,7 +308,7 @@ def test_get_objects_version(backend):
     assert objs["objects"][0]["id"] == "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "?match[version]=first",
+        test.GET_OBJECTS_EP + "?match[spec_version]=2.0,2.1&match[version]=first",
         headers=backend.headers,
     )
 
@@ -334,7 +334,7 @@ def test_get_objects_version(backend):
             assert obj["modified"] == "2017-01-27T13:49:53.935Z"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "?match[version]=all",
+        test.GET_OBJECTS_EP + "?match[spec_version]=2.0,2.1&match[version]=all",
         headers=backend.headers,
     )
 
@@ -356,7 +356,6 @@ def test_get_objects_spec_version(backend):
     objs = r.json
     assert objs['more'] is False
     assert len(objs['objects']) == 1
-    assert all(obj['spec_version'] == "2.0" for obj in objs['objects'])
 
     r = backend.client.get(
         test.GET_OBJECTS_EP + "?match[spec_version]=2.1",
@@ -413,7 +412,7 @@ def test_get_object_limit(backend):
     assert len(objs['objects']) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all&limit=2",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all&limit=2",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -425,7 +424,7 @@ def test_get_object_limit(backend):
     assert len(objs['objects']) == 2
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all&limit=2&next=" + objs['next'],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all&limit=2&next=" + objs['next'],
         headers=backend.headers,
         follow_redirects=True
     )
@@ -439,7 +438,7 @@ def test_get_object_limit(backend):
 
 def test_get_object_version(backend):
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=2016-12-25T12:30:59.444Z",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=2016-12-25T12:30:59.444Z",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -453,7 +452,7 @@ def test_get_object_version(backend):
     assert objs["objects"][0]["modified"] == "2016-12-25T12:30:59.444Z"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=first",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=first",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -481,7 +480,7 @@ def test_get_object_version(backend):
     assert objs["objects"][0]["id"] == "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[version]=all",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.0,2.1&match[version]=all",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -505,7 +504,6 @@ def test_get_object_spec_version(backend):
     objs = r.json
     assert objs['more'] is False
     assert len(objs['objects']) == 1
-    assert all(obj['spec_version'] == "2.0" for obj in objs['objects'])
 
     r = backend.client.get(
         test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e?match[spec_version]=2.1",
@@ -610,7 +608,7 @@ def test_get_manifest_version(backend):
     object_id = "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e"
 
     r = backend.client.get(
-        test.GET_MANIFESTS_EP + "?match[version]=2016-11-03T12:30:59.000Z",
+        test.GET_MANIFESTS_EP + "?match[spec_version]=2.0,2.1&match[version]=2016-11-03T12:30:59.000Z",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -624,7 +622,7 @@ def test_get_manifest_version(backend):
     assert objs["objects"][0]["version"] == "2016-11-03T12:30:59.000Z"
 
     r = backend.client.get(
-        test.GET_MANIFESTS_EP + "?match[version]=first",
+        test.GET_MANIFESTS_EP + "?match[spec_version]=2.0,2.1&match[version]=first",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -638,7 +636,7 @@ def test_get_manifest_version(backend):
     assert objs["objects"][2]["version"] == "2016-11-03T12:30:59.000Z"
 
     r = backend.client.get(
-        test.GET_MANIFESTS_EP + "?match[version]=last",
+        test.GET_MANIFESTS_EP + "?match[spec_version]=2.0,2.1&match[version]=last",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -652,7 +650,7 @@ def test_get_manifest_version(backend):
     assert objs["objects"][4]["version"] == "2017-01-27T13:49:53.935Z"
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "?match[version]=all",
+        test.GET_OBJECTS_EP + "?match[spec_version]=2.0,2.1&match[version]=all",
         headers=backend.headers,
         follow_redirects=True
     )
@@ -720,7 +718,7 @@ def test_get_version_added_after(backend):
 def test_get_version_limit(backend):
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1",
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1",
         headers=backend.headers,
         follow_redirects=True,
     )
@@ -732,7 +730,7 @@ def test_get_version_limit(backend):
     assert len(objs["versions"]) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1&next=" + objs["next"],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1&next=" + objs["next"],
         headers=backend.headers,
         follow_redirects=True,
     )
@@ -744,7 +742,7 @@ def test_get_version_limit(backend):
     assert len(objs["versions"]) == 1
 
     r = backend.client.get(
-        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?limit=1&next=" + objs["next"],
+        test.GET_OBJECTS_EP + "indicator--6770298f-0fd8-471a-ab8c-1c658a46574e/versions?match[spec_version]=2.0,2.1&limit=1&next=" + objs["next"],
         headers=backend.headers,
         follow_redirects=True,
     )


### PR DESCRIPTION
- This simplified some of the pipeline stages
   - Improved performance but slow for general requests - depends on collection size, object types
   - Fixed a problem in the pipeline not correctly filtering latest objects by spec_version or version
- Changes how we store documents to be 1:1 object-manifest 
- Some Backend Endpoint logic was simplified thanks to the new architecture
- Minimal changes to tests to make them pass