### PR TITLE
Improve backend subclassing and loading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,6 @@ To use the Memory back-end plug, include the following in the <config-file>:
 
     {
         "backend": {
-            "module": "medallion.backends.memory_backend",
             "module_class": "MemoryBackend",
             "filename": "<path to json file with initial data>"
         }
@@ -111,7 +110,6 @@ To use the Mongo DB back-end plug, include the following in the <config-file>:
 
     {
          "backend": {
-            "module": "medallion.backends.mongodb_backend",
             "module_class": "MongoBackend",
             "uri": "<Mongo DB server url>  # e.g., 'mongodb://localhost:27017/'"
          }

--- a/docker_utils/docker_config.json
+++ b/docker_utils/docker_config.json
@@ -1,6 +1,5 @@
 {
   "backend": {
-    "module": "medallion.backends.mongodb_backend",
     "module_class": "MongoBackend",
     "uri": "mongodb://root:example@mongo:27017/"
   },

--- a/docs/custom_backend.rst
+++ b/docs/custom_backend.rst
@@ -4,26 +4,87 @@ Custom Backends and Users
 How to create your custom Backend
 ---------------------------------
 
-To create a custom Backend compatible with medallion you need to subclass ``medallion.backends.taxii.base.Backend``. This object provides the basic skeleton used to handle each of the endpoint requests.
-
-For further examples of on how to build a custom backend look under the ``\medallion\backends\`` directory.
+To create a custom Backend compatible with medallion you should subclass
+``medallion.backends.Backend``. This object provides the basic skeleton used to
+handle each of the endpoint requests. For further examples of on how to build a
+custom backend look under the ``medallion/backends/`` directory.
 
 How to load your custom Backend
 -------------------------------
 
-New changes made to the library makes it easy to dynamically load a new backend into your medallion server. You only need to provide the module path and the class you wish to instantiate for the medallion server. Any other key value pairs found under the ``backend`` value can be used to pass arguments to your custom backend. For example,
+Backends are loaded based on the content of the ``backend`` map element in the
+``medallion`` configuration file. Built-in backend implementations can be
+loaded by simply setting the ``module_class`` key to the subclass' names. Extra
+keyword arguments can be passed to the backend implementation by including them
+in the ``backend`` map element. A simple example of loading the built-in
+``MemoryBackend`` and passing it a keyword argument looks like:
 
 .. code-block:: json
 
     {
         "backend": {
-            "module": "medallion.backends.taxii.memory_backend",
             "module_class": "MemoryBackend",
             "filename": "../test/data/default_data.json"
         }
     }
 
-Another way to provide a custom backend using flask proxy could be,
+Loading custom backends can be a little more complicated depending on how the
+backend class is implemented. If the custom backend subclasses the base
+``Backend`` and is somehow imported prior to starting the ``medallion`` flask
+application, the configuration file may simply refer to it by name in the
+``module_class`` key. This might be useful in environments where it is
+preferable to use something like the Python ``site`` module rather than
+installing an extra package.
+
+.. code-block:: json
+
+    {
+        "backend": {
+            "module_class": "MyCustomBackend",
+        }
+    }
+
+To make loading out-of-tree backend implementations easier, the
+``medallion.backends`` entrypoint is defined which may be used by other
+packages to point to external modules or classes which should be loaded by the
+backend machinery. This should be defined in your package's ``setup.py`` like:
+
+.. code-block:: python
+
+    setup(
+        # ...
+        entry_points={
+            "medallion.backends": [
+                "MyEPName = mypackage.with_backends:MyCustomBackend",
+            ],
+        }
+    )
+
+The entrypoint will be loaded and if it refers to a class object it will be
+registered with the base ``Backend`` class using the entrypoint's name. If the
+entrypoint is a subclass of the base ``Backend``, it will also be registered
+using the name of the loaded class object, supporting the use of implementation
+which do not subclass the base ``Backend`` properly. The entrypoint might also
+validly point to a module to be loaded, in which case any backend
+implementations must be subclasses of the base ``Backend`` and they will be
+registered under their class names.
+
+A previous implementation allowed a dotted module path to be specified in the
+``module`` key of the ``backend`` map in the configuration. This behaviour is
+deprecated but will continue to work with a warning. This is done to allow
+implementations to pivot to using the entry-point mechanism instead. An example
+configuration snippet for this approach looks like:
+
+.. code-block:: json
+
+    {
+        "backend": {
+            "module": "mypackage.with_backends",
+            "module_class": "MyCustomBackend",
+        }
+    }
+
+Another way to provide a custom backend using flask proxy could be:
 
 .. code-block:: python
 

--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -59,7 +59,7 @@ def set_config(flask_application_instance, prop_name, config):
                 log.warning("We are giving medallion the default settings,")
                 log.warning("which includes a data file of 'default_data.json'.")
                 log.warning("Please ensure this file is in your CWD.")
-                back = {'module': 'medallion.backends.memory_backend', 'module_class': 'MemoryBackend', 'filename': None}
+                back = {'module_class': 'MemoryBackend', 'filename': None}
                 flask_application_instance.medallion_backend = connect_to_backend(back)
 
 

--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -1,9 +1,11 @@
 import importlib
 import logging
+import warnings
 
 from flask import Flask, Response, current_app, json
 from flask_httpauth import HTTPBasicAuth
 
+from .backends import base as mbe_base
 from .exceptions import BackendError, ProcessingError
 from .version import __version__  # noqa
 from .views import MEDIA_TYPE_TAXII_V21
@@ -64,19 +66,50 @@ def set_config(flask_application_instance, prop_name, config):
 def connect_to_backend(config_info):
     log.debug("Initializing backend configuration using: {}".format(config_info))
 
-    if "module" not in config_info:
-        raise ValueError("No module parameter provided for the TAXII server.")
-    if "module_class" not in config_info:
+    try:
+        backend_cls_name = config_info["module_class"]
+    except KeyError:
         raise ValueError("No module_class parameter provided for the TAXII server.")
 
     try:
-        module = importlib.import_module(config_info["module"])
-        module_class = getattr(module, config_info["module_class"])
-        log.debug("Instantiating medallion backend with {}".format(module_class))
-        return module_class(**config_info)
-    except Exception as e:
-        log.error("Unknown backend for TAXII server. {} ".format(str(e)))
-        raise
+        backend_mod_name = config_info["module"]
+    except KeyError:
+        # Handle configurations which only specify a backend class name
+        try:
+            backend_cls = mbe_base.BackendRegistry.get(backend_cls_name)
+        except KeyError as exc:
+            msg = "Unknown backend {!r}".format(backend_cls_name)
+            log.error(msg)
+            raise ValueError(msg) from exc
+    else:
+        # Handle configurations which specify a module to load
+        warnings.warn(
+            "Backend module paths in configuration will be removed in future. "
+            "Simply use the backend class name in 'module_class' for builtin "
+            "backend implementations.",
+            DeprecationWarning
+        )
+        try:
+            backend_mod = importlib.import_module(backend_mod_name)
+            backend_cls = getattr(backend_mod, backend_cls_name)
+        except (ImportError, AttributeError) as exc:
+            log.error(
+                "Failed to load backend %r from %r",
+                backend_cls_name, backend_mod_name,
+            )
+            raise exc
+        else:
+            log.debug(
+                "Instantiating medallion backend with %r from %r",
+                backend_cls_name, backend_mod_name,
+            )
+
+    # Finally, instantiate the backend class with the configuration passed in
+    try:
+        return backend_cls(**config_info)
+    except BaseException as exc:
+        log.error("Failed to instantiate %r: %s", backend_cls_name, exc)
+        raise exc
 
 
 def register_blueprints(flask_application_instance):

--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -85,8 +85,8 @@ def connect_to_backend(config_info):
         # Handle configurations which specify a module to load
         warnings.warn(
             "Backend module paths in configuration will be removed in future. "
-            "Simply use the backend class name in 'module_class' for builtin "
-            "backend implementations.",
+            "Simply use the backend class name in 'module_class' or add a "
+            "medallion.backends entrypoint for more exotic implementations.",
             DeprecationWarning
         )
         try:

--- a/medallion/backends/__init__.py
+++ b/medallion/backends/__init__.py
@@ -1,6 +1,11 @@
 import importlib
+import inspect
 import pkgutil
 import sys
+
+import pkg_resources
+
+from . import base
 
 # Walk this package and import all sub-modules so the can instantiate backends
 _paths = sys.modules[__name__].__path__
@@ -8,3 +13,10 @@ for _, subname, _ in pkgutil.walk_packages(_paths):
     mod_obj = importlib.import_module(__name__ + "." + subname)
     if "." not in subname:
         globals()[subname] = mod_obj
+
+# Load all defined backend entry points - we orphan them after loading rather
+# than injecting them into this module, instead replying on `__init_subclass__`
+for ep in pkg_resources.iter_entry_points("medallion.backends"):
+    ep_obj = ep.load()
+    if inspect.isclass(ep_obj):
+        base.BackendRegistry.register(ep.name, ep_obj)

--- a/medallion/backends/__init__.py
+++ b/medallion/backends/__init__.py
@@ -5,6 +5,6 @@ import sys
 # Walk this package and import all sub-modules so the can instantiate backends
 _paths = sys.modules[__name__].__path__
 for _, subname, _ in pkgutil.walk_packages(_paths):
-    mod_obj = importlib.import_module( __name__ + "." + subname)
+    mod_obj = importlib.import_module(__name__ + "." + subname)
     if "." not in subname:
         globals()[subname] = mod_obj

--- a/medallion/backends/__init__.py
+++ b/medallion/backends/__init__.py
@@ -1,0 +1,10 @@
+import importlib
+import pkgutil
+import sys
+
+# Walk this package and import all sub-modules so the can instantiate backends
+_paths = sys.modules[__name__].__path__
+for _, subname, _ in pkgutil.walk_packages(_paths):
+    mod_obj = importlib.import_module( __name__ + "." + subname)
+    if "." not in subname:
+        globals()[subname] = mod_obj

--- a/medallion/backends/__init__.py
+++ b/medallion/backends/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
-import pkgutil
 import logging
+import pkgutil
 import sys
 
 import pkg_resources

--- a/medallion/backends/base.py
+++ b/medallion/backends/base.py
@@ -1,5 +1,26 @@
+class BackendRegistry(type):
+    __SUBCLASS_MAP = dict()
 
-class Backend(object):
+    def __new__(mcls, name, bases, attrs):
+        clsobj = super(BackendRegistry, mcls).__new__(mcls, name, bases, attrs)
+        mcls.register(name, clsobj)
+        return clsobj
+
+    @classmethod
+    def register(mcls, kind, clsobj):
+        if mcls.__SUBCLASS_MAP.get(kind, clsobj) is not clsobj:
+            raise ValueError(
+                "Backend name {!r} registered more than once"
+                .format(kind)
+            )
+        mcls.__SUBCLASS_MAP[kind] = clsobj
+
+    @classmethod
+    def get(mcls, kind):
+        return mcls.__SUBCLASS_MAP[kind]
+
+
+class Backend(object, metaclass=BackendRegistry):
 
     def server_discovery(self):
         """

--- a/medallion/test/base_test.py
+++ b/medallion/test/base_test.py
@@ -27,7 +27,6 @@ class TaxiiTest():
 
     config_no_taxii = {
         "backend": {
-            "module": "medallion.backends.memory_backend",
             "module_class": "MemoryBackend",
             "filename": DATA_FILE,
         },
@@ -38,7 +37,6 @@ class TaxiiTest():
 
     config_no_auth = {
         "backend": {
-            "module": "medallion.backends.memory_backend",
             "module_class": "MemoryBackend",
             "filename": DATA_FILE,
         },
@@ -58,7 +56,6 @@ class TaxiiTest():
 
     memory_config = {
         "backend": {
-            "module": "medallion.backends.memory_backend",
             "module_class": "MemoryBackend",
             "filename": DATA_FILE,
         },
@@ -72,7 +69,6 @@ class TaxiiTest():
 
     mongodb_config = {
         "backend": {
-            "module": "medallion.backends.mongodb_backend",
             "module_class": "MongoBackend",
             "uri": "mongodb://travis:test@127.0.0.1:27017/",
         },

--- a/medallion/test/config/test_backend_config.py
+++ b/medallion/test/config/test_backend_config.py
@@ -1,0 +1,120 @@
+import unittest.mock as mock
+
+import pytest
+
+import medallion
+from medallion.backends import base as mbe_base
+from medallion.backends import memory_backend as mbe_mem
+
+
+class SavesArgs(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def test_backend_registration():
+    """
+    Sanity test that backends get registered in the base class.
+    """
+    with mock.patch(
+        "medallion.backends.base.BackendRegistry.register",
+    ) as mock_reg:
+        class Foo(mbe_base.Backend):
+            pass
+    mock_reg.assert_called_once_with("Foo", Foo)
+
+
+class TestBackendConfig:
+    def test_backend_without_name(self):
+        with pytest.raises(ValueError):
+            medallion.connect_to_backend(dict())
+
+    def test_backend_lookup(self):
+        cfg = {"module_class": mock.sentinel.class_name}
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+        ) as mock_find:
+            medallion.connect_to_backend(cfg)
+        mock_find.assert_called_once_with(mock.sentinel.class_name)
+
+    def test_backend_lookup_unknown(self):
+        cfg = {"module_class": mock.sentinel.class_name}
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+            side_effect=KeyError,
+        ) as mock_find:
+            with pytest.raises(ValueError):
+                medallion.connect_to_backend(cfg)
+        mock_find.assert_called_once_with(mock.sentinel.class_name)
+
+    def test_backend_instantiation(self):
+        cfg = {"module_class": mock.sentinel.class_name}
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+        ) as mock_find:
+            be_obj = medallion.connect_to_backend(cfg)
+        mock_find.assert_called_once_with(mock.sentinel.class_name)
+        assert be_obj is mock_find.return_value()
+
+    def test_backend_instantiation_raises(self):
+        class SentinelError(BaseException):
+            pass
+
+        cfg = {"module_class": mock.sentinel.class_name}
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+            return_value=mock.MagicMock(side_effect=SentinelError),
+        ) as mock_find:
+            with pytest.raises(SentinelError):
+                medallion.connect_to_backend(cfg)
+        mock_find.assert_called_once_with(mock.sentinel.class_name)
+
+    def test_backend_instantiation_with_args(self):
+        cfg = {
+            "module_class": mock.sentinel.class_name,
+            "foo": 42, "bar": "baz",
+        }
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+        ) as mock_find:
+            be_obj = medallion.connect_to_backend(cfg)
+        mock_find.assert_called_once_with(mock.sentinel.class_name)
+        mock_find.return_value.assert_called_once_with(**cfg)
+        assert be_obj is mock_find.return_value()
+
+    def test_builtin_backend(self):
+        be_obj = medallion.connect_to_backend(dict(
+            module_class="MemoryBackend",
+        ))
+        assert isinstance(be_obj, mbe_mem.MemoryBackend)
+
+    def test_backend_module_path(self):
+        cfg = {
+            "module": __name__,
+            "module_class": "SavesArgs",
+        }
+        with mock.patch(
+            "medallion.backends.base.BackendRegistry.get",
+        ) as mock_find:
+            be_obj = medallion.connect_to_backend(cfg)
+        assert mock_find.call_count == 0
+        assert isinstance(be_obj, SavesArgs)
+        assert be_obj.args == tuple()
+        assert be_obj.kwargs == cfg
+
+    def test_backend_module_path_nonexistent(self):
+        cfg = {
+            "module": "nonexistent.module.path",
+            "module_class": mock.sentinel.class_name,
+        }
+        with pytest.raises(ImportError):
+            medallion.connect_to_backend(cfg)
+
+    def test_backend_module_name_nonexistent(self):
+        cfg = {
+            "module": __name__,
+            "module_class": "NonexistentClassName",
+        }
+        with pytest.raises(AttributeError):
+            medallion.connect_to_backend(cfg)

--- a/medallion/test/data/config.json
+++ b/medallion/test/data/config.json
@@ -1,6 +1,5 @@
 {
   "backend": {
-    "module": "medallion.backends.memory_backend",
     "module_class": "MemoryBackend",
     "filename": "../test/data/default_data.json"
   },


### PR DESCRIPTION
This changeset makes it easier to load backends using a subclass registry
and entrypoints. The use of the `module` key in backend configuration is
deprecated and a warning will be printed telling users to update their config
files and define entrypoints if they need to for custom backends.