### PR TITLE
Check for manifest at server creation, addressing bug #92

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ Temporary Items
 .apdisk
 /configs/
 /data/
+medallion/test/data/config2.json
+medallion/test/data/config.json
+medallion/test/data/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,3 @@ Temporary Items
 .apdisk
 /configs/
 /data/
-medallion/test/data/config2.json
-medallion/test/data/config.json
-medallion/test/data/config.json

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -128,8 +128,7 @@ class MemoryBackend(Backend):
         Checks collections for proper manifest, if objects are present in a collection, a manifest should be present with
         an entry for each entry in objects
         """
-        for key in self.data:
-            api_root = self.data[key]
+        for key, api_root in self.data.items():
             for collection in api_root.get('collections', []):
                 if not collection.get('objects'):
                     continue

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -144,7 +144,7 @@ class MemoryBackend(Backend):
                         if obj['id'] == man['id'] and obj_time == man_time:
                             obj_man_paired = True
                     if not obj_man_paired: 
-                        raise InitializationError("Object with id {} last modified on {} is missing a manifest".format(obj['id'], obj_time), 408)
+                        raise InitializationError("Object with id {} from {} is missing a manifest".format(obj['id'], obj_time), 408)
     def load_data_from_file(self, filename):
         if isinstance(filename, string_types):
             with io.open(filename, "r", encoding="utf-8") as infile:

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -458,4 +458,3 @@ class MemoryBackend(Backend):
                         objs = sorted(map(lambda x: x["version"], objs), reverse=True)
                         break
             return create_resource("versions", objs, more, n), headers
-

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -130,20 +130,21 @@ class MemoryBackend(Backend):
         """
         for key, api_root in self.data:
             for collection in api_root.get('collections', [])
-                if collection['objects']:
-                    if 'manifest' not in collection:
-                        raise InitializationError("Collection {} manifest is missing".format(collection['id']), 408)
-                    else if not collection['manifest']:
-                        raise InitializationError("Collection {} with objects has an empty manifest".format(collection['id']), 408)
-                    for obj in collection.get('objects', []):
-                        obj_time=find_att(obj)
-                        obj_man_paired = False
-                        for man in collection['manifest']:
-                            man_time = find_att(man)
-                            if obj['id'] == man['id'] and obj_time == man_time:
-                                obj_man_paired = True
-                        if not obj_man_paired: 
-                            raise InitializationError("Object with id {} last modified on {} is missing a manifest".format(obj['id'], obj_time), 408)
+                if not collection.get('objects'):
+                    continue
+                if 'manifest' not in collection:
+                    raise InitializationError("Collection {} manifest is missing".format(collection['id']), 408)
+                else if not collection['manifest']:
+                    raise InitializationError("Collection {} with objects has an empty manifest".format(collection['id']), 408)
+                for obj in collection.get('objects', []):
+                    obj_time=find_att(obj)
+                    obj_man_paired = False
+                    for man in collection['manifest']:
+                        man_time = find_att(man)
+                        if obj['id'] == man['id'] and obj_time == man_time:
+                            obj_man_paired = True
+                    if not obj_man_paired: 
+                        raise InitializationError("Object with id {} last modified on {} is missing a manifest".format(obj['id'], obj_time), 408)
     def load_data_from_file(self, filename):
         if isinstance(filename, string_types):
             with io.open(filename, "r", encoding="utf-8") as infile:

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -128,6 +128,7 @@ class MemoryBackend(Backend):
         Checks collections for proper manifest, if objects are present in a collection, a manifest should be present with
         an entry for each entry in objects
         """
+
         for key, api_root in self.data.items():
             for collection in api_root.get('collections', []):
                 if not collection.get('objects'):
@@ -137,7 +138,7 @@ class MemoryBackend(Backend):
                 if not collection['manifest']:
                     raise InitializationError("Collection {} with objects has an empty manifest".format(collection['id']), 408)
                 for obj in collection.get('objects', []):
-                    obj_time=find_att(obj)
+                    obj_time = find_att(obj)
                     obj_man_paired = False
                     for man in collection['manifest']:
                         man_time = find_att(man)
@@ -146,14 +147,13 @@ class MemoryBackend(Backend):
                             break
                     if not obj_man_paired:
                         raise InitializationError("Object with id {} from {} is missing a manifest".format(obj['id'], obj_time), 408)
+
     def load_data_from_file(self, filename):
         if isinstance(filename, string_types):
             with io.open(filename, "r", encoding="utf-8") as infile:
                 self.data = json.load(infile)
         else:
             self.data = json.load(filename)
-
-
 
     def save_data_to_file(self, filename, **kwargs):
         """The kwargs are passed to ``json.dump()`` if provided."""

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -123,6 +123,7 @@ class MemoryBackend(Backend):
 
         for item in expired_ids:
             self.next.pop(item)
+
     def collections_manifest_check(self):
         """
         Checks collections for proper manifest, if objects are present in a collection, a manifest should be present with
@@ -457,3 +458,4 @@ class MemoryBackend(Backend):
                         objs = sorted(map(lambda x: x["version"], objs), reverse=True)
                         break
             return create_resource("versions", objs, more, n), headers
+

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -123,28 +123,27 @@ class MemoryBackend(Backend):
 
         for item in expired_ids:
             self.next.pop(item)
-    #checks collections for proper manifest, if objects are present in a collection, a manifest should be present with 
-    #an entry for each entry in objects
     def collections_manifest_check(self):
-        for group in self.data:
-            if 'collections' in self.data[group].keys():
-                collections = self.data[group]['collections']
-                if collections:
-                    for collection in collections:
-                        if collection['objects']:
-                            if 'manifest' not in collection:
-                                raise InitializationError("Collection {} manifest is missing".format(collection['id']), 408)
-                            if not collection['manifest']:
-                                raise InitializationError("Collection {} with objects has an empty manifest".format(collection['id']), 408)
-                            for obj in collection['objects']:
-                                obj_time=find_att(obj)
-                                obj_man_paired = False
-                                for man in collection['manifest']:
-                                    man_time = find_att(man)
-                                    if obj['id'] == man['id'] and obj_time == man_time:
-                                        obj_man_paired = True
-                                if not obj_man_paired: 
-                                    raise InitializationError("Object with id {} last modified on {} is missing a manifest".format(obj['id'], obj_time), 408)
+        """
+        Checks collections for proper manifest, if objects are present in a collection, a manifest should be present with 
+        an entry for each entry in objects
+        """
+        for key, api_root in self.data:
+            for collection in api_root.get('collections', [])
+                if collection['objects']:
+                    if 'manifest' not in collection:
+                        raise InitializationError("Collection {} manifest is missing".format(collection['id']), 408)
+                    else if not collection['manifest']:
+                        raise InitializationError("Collection {} with objects has an empty manifest".format(collection['id']), 408)
+                    for obj in collection.get('objects', []):
+                        obj_time=find_att(obj)
+                        obj_man_paired = False
+                        for man in collection['manifest']:
+                            man_time = find_att(man)
+                            if obj['id'] == man['id'] and obj_time == man_time:
+                                obj_man_paired = True
+                        if not obj_man_paired: 
+                            raise InitializationError("Object with id {} last modified on {} is missing a manifest".format(obj['id'], obj_time), 408)
     def load_data_from_file(self, filename):
         if isinstance(filename, string_types):
             with io.open(filename, "r", encoding="utf-8") as infile:
@@ -456,3 +455,4 @@ class MemoryBackend(Backend):
                         objs = sorted(map(lambda x: x["version"], objs), reverse=True)
                         break
             return create_resource("versions", objs, more, n), headers
+

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -145,15 +145,15 @@ class MongoBackend(Backend):
                 results = objects.find({})
                 for result in results:
                     if "_manifest" not in result:
+                        field_to_use = 'created'
                         if "modified" in result:
-                            raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result['modified']), 408)
-                        else:
-                            raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result['created']), 408)
+                            field_to_use = 'modified'
+                        raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result[field_to_use]), 408)
                     if not result['_manifest']:
+                        field_to_use = 'created'
                         if "modified" in result:
-                            raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result['modified']), 408)
-                        else:
-                            raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result['created']), 408)
+                            field_to_use = 'modified'
+                        raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result[field_to_use]), 408)
         if not objects_exists:
             raise InitializationError("Could not find any objects in database", 408)
 

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -143,8 +143,7 @@ class MongoBackend(Backend):
             objects_exists = True
             api_root_db = db[api_root]
             objects = api_root_db["objects"]
-            results = objects.find({})
-            for result in results:
+            for result in objects.find({}):
                 if "_manifest" not in result:
                     field_to_use = 'created'
                     if "modified" in result:

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -131,6 +131,9 @@ class MongoBackend(Backend):
             return manifest_resource, headers
 
     def object_manifest_check(self):
+        """
+        Checks for manifests in each object, throws an error if not present.
+        """
         db = self.client
         objects_exists = False
         for api_root in db.list_database_names():

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -12,7 +12,9 @@ from ..common import (
     get_custom_headers, get_timestamp, parse_request_parameters,
     string_to_datetime
 )
-from ..exceptions import MongoBackendError, ProcessingError
+from ..exceptions import (
+    InitializationError, MongoBackendError, ProcessingError
+)
 from ..filters.mongodb_filter import MongoDBFilter
 from .base import Backend
 
@@ -43,6 +45,7 @@ class MongoBackend(Backend):
     def __init__(self, **kwargs):
         try:
             self.client = MongoClient(kwargs.get("uri"))
+            self.object_manifest_check()
             self.pages = {}
             self.timeout = kwargs.get("session_timeout", 30)
         except ConnectionFailure:
@@ -126,6 +129,30 @@ class MongoBackend(Backend):
         else:
             headers = get_custom_headers(manifest_resource)
             return manifest_resource, headers
+
+    def object_manifest_check(self):
+        db = self.client
+        objects_exists = False
+        for api_root in db.list_database_names():
+            cols = db[api_root].list_collection_names()
+            if "objects" in cols:
+                objects_exists = True
+                api_root_db = db[api_root]
+                objects = api_root_db["objects"]
+                results = objects.find({})
+                for result in results:
+                    if "_manifest" not in result:
+                        if "modified" in result:
+                            raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result['modified']), 408)
+                        else:
+                            raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result['created']), 408)
+                    if not result['_manifest']:
+                        if "modified" in result:
+                            raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result['modified']), 408)
+                        else:
+                            raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result['created']), 408)
+        if not objects_exists:
+            raise InitializationError("Could not find any objects in database", 408)
 
     @catch_mongodb_error
     def _update_manifest(self, api_root, collection_id, media_type):

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -138,22 +138,23 @@ class MongoBackend(Backend):
         objects_exists = False
         for api_root in db.list_database_names():
             cols = db[api_root].list_collection_names()
-            if "objects" in cols:
-                objects_exists = True
-                api_root_db = db[api_root]
-                objects = api_root_db["objects"]
-                results = objects.find({})
-                for result in results:
-                    if "_manifest" not in result:
-                        field_to_use = 'created'
-                        if "modified" in result:
-                            field_to_use = 'modified'
-                        raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result[field_to_use]), 408)
-                    if not result['_manifest']:
-                        field_to_use = 'created'
-                        if "modified" in result:
-                            field_to_use = 'modified'
-                        raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result[field_to_use]), 408)
+            if "objects" not in cols:
+                continue
+            objects_exists = True
+            api_root_db = db[api_root]
+            objects = api_root_db["objects"]
+            results = objects.find({})
+            for result in results:
+                if "_manifest" not in result:
+                    field_to_use = 'created'
+                    if "modified" in result:
+                        field_to_use = 'modified'
+                    raise InitializationError("Object {} from {} is missing a manifest".format(result['id'], result[field_to_use]), 408)
+                if not result['_manifest']:
+                    field_to_use = 'created'
+                    if "modified" in result:
+                        field_to_use = 'modified'
+                    raise InitializationError("Object {} from {} has a null manifest".format(result['id'], result[field_to_use]), 408)
         if not objects_exists:
             raise InitializationError("Could not find any objects in database", 408)
 

--- a/medallion/exceptions.py
+++ b/medallion/exceptions.py
@@ -24,9 +24,11 @@ class ProcessingError(MedallionError):
     """Internal processing error when processing user supplied data"""
     pass
 
+
 class InitializationError(MedallionError):
     """Medallion Initialization Error, such as bad initial data"""
     pass
+
 
 class BackendError(MedallionError):
     """Medallion data backend error"""

--- a/medallion/exceptions.py
+++ b/medallion/exceptions.py
@@ -24,6 +24,9 @@ class ProcessingError(MedallionError):
     """Internal processing error when processing user supplied data"""
     pass
 
+class InitializationError(MedallionError):
+    """Medallion Initialization Error, such as bad initial data"""
+    pass
 
 class BackendError(MedallionError):
     """Medallion data backend error"""
@@ -33,3 +36,4 @@ class BackendError(MedallionError):
 class MongoBackendError(BackendError):
     """Cannot connect or obtain access to MongoDB backend"""
     pass
+

--- a/medallion/exceptions.py
+++ b/medallion/exceptions.py
@@ -38,4 +38,3 @@ class BackendError(MedallionError):
 class MongoBackendError(BackendError):
     """Cannot connect or obtain access to MongoDB backend"""
     pass
-


### PR DESCRIPTION
Adds error handling that checks for object manifests at server creation, throws an error if an object does not have a matching manifest