### PR TITLE
Change re-adding objects to be a successful no-op instead of failure

### DIFF
--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -332,18 +332,16 @@ class MemoryBackend(Backend):
                                     new_obj["_date_added"] = version
                                 collection["objects"].append(new_obj)
                                 self._update_manifest(new_obj, api_root, collection["id"], request_time)
-                                status_details = generate_status_details(
-                                    new_obj["id"], version
-                                )
-                                successes.append(status_details)
-                                succeeded += 1
-                            else:
-                                status_details = generate_status_details(
-                                    new_obj["id"], determine_version(new_obj, request_time),
-                                    message="Unable to process object",
-                                )
-                                failures.append(status_details)
-                                failed += 1
+
+                            # else: we already have the object, so this is a
+                            # no-op.
+
+                            status_details = generate_status_details(
+                                new_obj["id"], version
+                            )
+                            successes.append(status_details)
+                            succeeded += 1
+
                     except Exception as e:
                         raise ProcessingError("While processing supplied content, an error occurred", 422, e)
 

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -327,7 +327,12 @@ class MemoryBackend(Backend):
                                         # There is no modified field, so this object is immutable
                                         id_and_version_already_present = True
                                         break
-                            if id_and_version_already_present is False:
+
+                            if id_and_version_already_present:
+                                message = "Object already added"
+
+                            else:
+                                message = None
                                 if "modified" not in new_obj and "created" not in new_obj:
                                     new_obj["_date_added"] = version
                                 collection["objects"].append(new_obj)
@@ -337,7 +342,7 @@ class MemoryBackend(Backend):
                             # no-op.
 
                             status_details = generate_status_details(
-                                new_obj["id"], version
+                                new_obj["id"], version, message
                             )
                             successes.append(status_details)
                             succeeded += 1

--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -315,6 +315,7 @@ class MemoryBackend(Backend):
                         collection["objects"] = []
                     try:
                         for new_obj in objs["objects"]:
+                            version = determine_version(new_obj, request_time)
                             id_and_version_already_present = False
                             for obj in collection["objects"]:
                                 if new_obj["id"] == obj["id"]:
@@ -327,7 +328,6 @@ class MemoryBackend(Backend):
                                         id_and_version_already_present = True
                                         break
                             if id_and_version_already_present is False:
-                                version = determine_version(new_obj, request_time)
                                 if "modified" not in new_obj and "created" not in new_obj:
                                     new_obj["_date_added"] = version
                                 collection["objects"].append(new_obj)

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -294,7 +294,12 @@ class MongoBackend(Backend):
                     mongo_query["_manifest.version"] = datetime_to_float(string_to_datetime(new_obj["modified"]))
                 existing_entry = objects_info.find_one(mongo_query)
                 obj_version = determine_version(new_obj, request_time)
-                if not existing_entry:
+
+                if existing_entry:
+                    message = "Object already added"
+
+                else:
+                    message = None
                     new_obj.update({"_collection_id": collection_id})
                     if "modified" in new_obj:
                         new_obj["modified"] = datetime_to_float(string_to_datetime(new_obj["modified"]))
@@ -314,8 +319,7 @@ class MongoBackend(Backend):
                 # no-op.
 
                 status_detail = generate_status_details(
-                    new_obj["id"], obj_version,
-                    message="Successfully added object to collection '{}'.".format(collection_id)
+                    new_obj["id"], obj_version, message
                 )
                 successes.append(status_detail)
                 succeeded += 1

--- a/medallion/test/test_backends.py
+++ b/medallion/test/test_backends.py
@@ -1388,7 +1388,7 @@ def test_default_backend_no_backend_section(no_backend_section):
 # test collections with different can_read and can_write values
 
 
-# test if program will reject duplicate objects being posted
+# test if program will accept duplicate objects being posted
 def test_object_already_present(backend):
     object_copy = {
                         "created": "2014-05-08T09:00:00.000Z",
@@ -1421,10 +1421,10 @@ def test_object_already_present(backend):
     )
     status_data = r_post.json
     assert r_post.status_code == 202
-    # should have failures
-    assert "failures" in status_data
-    # should not have successes
-    assert "successes" not in status_data
+    # should not have failures
+    assert "failures" not in status_data
+    # should have successes
+    assert "successes" in status_data
 
 
 def test_save_to_file(backend):


### PR DESCRIPTION
Fixes #149 .

Change memory and mongo backends to not treat addition of objects the backend already has, as "failures" with respect to the TAXII status resource.  This ought to be a very common occurrence with highly reused objects (e.g. TLP marking definitions), so it didn't make sense to think of them as some kind of error.  It is now treated as a no-op and a success.
