### PR TITLE
interop requirements

### DIFF
--- a/medallion/backends/memory_backend.py
+++ b/medallion/backends/memory_backend.py
@@ -1,6 +1,7 @@
 import copy
 import io
 import json
+import logging
 import os
 import uuid
 
@@ -8,13 +9,17 @@ import environ
 from six import string_types
 
 from ..common import (
-    SessionChecker, create_resource, datetime_to_float, datetime_to_string,
+    create_resource, datetime_to_float, datetime_to_string,
     determine_spec_version, determine_version, find_att, generate_status,
-    generate_status_details, get_timestamp, iterpath
+    generate_status_details, get_application_instance_config_values,
+    get_timestamp, iterpath, string_to_datetime
 )
 from ..exceptions import InitializationError, ProcessingError
 from ..filters.basic_filter import BasicFilter
 from .base import Backend
+
+# Module-level logger
+log = logging.getLogger(__name__)
 
 
 def remove_hidden_field(objs):
@@ -57,11 +62,27 @@ class MemoryBackend(Backend):
             self.collections_manifest_check()
         else:
             self.data = {}
-        self.next = {}
-        self.timeout = kwargs.get("session_timeout", 30)
+        super(MemoryBackend, self).__init__(**kwargs)
 
-        checker = SessionChecker(kwargs.get("check_interval", 10), self._pop_expired_sessions)
-        checker.start()
+    def _pop_expired_sessions(self):
+        expired_ids = []
+        boundary = datetime_to_float(get_timestamp())
+        for next_id, record in self.next.items():
+            if boundary - record["request_time"] > self.timeout:
+                expired_ids.append(next_id)
+
+        for item in expired_ids:
+            self.next.pop(item)
+
+    def _pop_old_statuses(self):
+        api_roots = self._get_all_api_roots()
+        boundary = datetime_to_float(get_timestamp())
+        for ar in api_roots:
+            statuses_of_api_root = copy.copy(self._get_api_root_statuses(ar))
+            for s in statuses_of_api_root:
+                if boundary - datetime_to_float(string_to_datetime(s["request_timestamp"])) > self.status_retention:
+                    self._get_api_root_statuses(ar).remove(s)
+                    log.info("Status {} was deleted from {} because it was older than the status retention time".format(s['id'], ar))
 
     def set_next(self, objects, args):
         u = str(uuid.uuid4())
@@ -113,16 +134,6 @@ class MemoryBackend(Backend):
             return ret, more, headers, nex
         else:
             raise ProcessingError("The server did not understand the request or filter parameters: 'next' not valid", 400)
-
-    def _pop_expired_sessions(self):
-        expired_ids = []
-        boundary = datetime_to_float(get_timestamp())
-        for next_id, record in self.next.items():
-            if boundary - record["request_time"] > self.timeout:
-                expired_ids.append(next_id)
-
-        for item in expired_ids:
-            self.next.pop(item)
 
     def collections_manifest_check(self):
         """
@@ -212,6 +223,9 @@ class MemoryBackend(Backend):
             collection.pop("manifest", None)
             collection.pop("responses", None)
             collection.pop("objects", None)
+        # interop wants results sorted by id - no need to check for interop option
+        if get_application_instance_config_values("backend", "interop_requirements"):
+            collections = sorted(collections, key=lambda o: o["id"])
         return create_resource("collections", collections)
 
     def get_collection(self, api_root, collection_id):
@@ -261,6 +275,12 @@ class MemoryBackend(Backend):
 
             if "information" in api_info:
                 return api_info["information"]
+
+    def _get_api_root_statuses(self, api_root):
+        api_info = self._get(api_root)
+
+        if "status" in api_info:
+            return api_info["status"]
 
     def get_status(self, api_root, status_id):
         if api_root in self.data:

--- a/medallion/backends/mongodb_backend.py
+++ b/medallion/backends/mongodb_backend.py
@@ -5,12 +5,13 @@ import environ
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 
+# from ..config import get_application_instance_config_values
 from ..common import (
-    SessionChecker, create_resource, datetime_to_float, datetime_to_string,
+    create_resource, datetime_to_float, datetime_to_string,
     datetime_to_string_stix, determine_spec_version, determine_version,
     float_to_datetime, generate_status, generate_status_details,
-    get_custom_headers, get_timestamp, parse_request_parameters,
-    string_to_datetime
+    get_application_instance_config_values, get_custom_headers, get_timestamp,
+    parse_request_parameters, string_to_datetime
 )
 from ..exceptions import (
     InitializationError, MongoBackendError, ProcessingError
@@ -44,15 +45,13 @@ class MongoBackend(Backend):
 
     def __init__(self, **kwargs):
         try:
+            super(MongoBackend, self).__init__(**kwargs)
+            self.pages = {}
             self.client = MongoClient(kwargs.get("uri"))
             self.object_manifest_check()
-            self.pages = {}
-            self.timeout = kwargs.get("session_timeout", 30)
+
         except ConnectionFailure:
             log.error("Unable to establish a connection to MongoDB server {}".format(kwargs.get("uri")))
-
-        checker = SessionChecker(kwargs.get("check_interval", 10), self._pop_expired_sessions)
-        checker.start()
 
     def _process_params(self, filter_args, limit):
         next_id = filter_args.get("next")
@@ -100,6 +99,40 @@ class MongoBackend(Backend):
 
         for item in expired_ids:
             self.pages.pop(item)
+
+    def _pop_old_statuses(self):
+        api_roots = self._get_all_api_roots()
+        status_retention_in_milliseconds = self.status_retention * 1000
+        for ar in api_roots:
+            statuses_of_api_root = self._get_api_root_statuses(ar)
+            result = statuses_of_api_root.aggregate([
+                    {
+                        "$project": {
+                            "id": 1,
+                            "date_difference": {
+                                "$subtract": [
+                                    "$$NOW",
+                                    {
+                                        "$dateFromString": {
+                                            "dateString": "$request_timestamp"
+                                        }
+                                    }
+                                ]
+                            },
+                        }
+                    },
+                    {
+                        "$match": {
+                            "date_difference": {
+                                "$gt": status_retention_in_milliseconds
+                            }
+                        }
+                    }
+                ]
+            )
+            for doc in result:
+                log.info("Status {} was deleted from {} because it was older than the status retention time".format(doc["id"], ar))
+                statuses_of_api_root.delete_one({"_id": doc["_id"]})
 
     def _get_object_manifest(self, api_root, collection_id, filter_args, allowed_filters, limit, internal=False):
         api_root_db = self.client[api_root]
@@ -207,6 +240,9 @@ class MongoBackend(Backend):
         api_root_db = self.client[api_root]
         collection_info = api_root_db["collections"]
         collections = list(collection_info.find({}, {"_id": 0}))
+        # interop wants results sorted by id - no need to check for interop option
+        if get_application_instance_config_values("backend", "interop_requirements"):
+            collections = sorted(collections, key=lambda o: o["id"])
         return create_resource("collections", collections)
 
     @catch_mongodb_error
@@ -232,6 +268,11 @@ class MongoBackend(Backend):
             {"_id": 0, "_url": 0, "_name": 0}
         )
         return info
+
+    @catch_mongodb_error
+    def _get_api_root_statuses(self, api_root):
+        api_root_db = self.client[api_root]
+        return api_root_db["status"]
 
     @catch_mongodb_error
     def get_status(self, api_root, status_id):

--- a/medallion/common.py
+++ b/medallion/common.py
@@ -3,8 +3,11 @@ import datetime as dt
 import threading
 import uuid
 
+from flask import Flask
 import pytz
 from six import iteritems
+
+APPLICATION_INSTANCE = Flask(__name__)
 
 
 def create_resource(resource_name, items, more=False, next_id=None):
@@ -251,7 +254,7 @@ def find_version_attribute(obj):
         return "_date_added"
 
 
-class SessionChecker(object):
+class TaskChecker(object):
     """Calls a target method every X seconds to perform a task."""
 
     def __init__(self, interval, target_function):
@@ -268,3 +271,21 @@ class SessionChecker(object):
 
     def start(self):
         self.thread.start()
+
+
+def get_application_instance_config_values(config_group, config_key=None):
+    if config_group == "taxii":
+        if APPLICATION_INSTANCE.taxii_config and config_key in APPLICATION_INSTANCE.taxii_config:
+            return APPLICATION_INSTANCE.taxii_config[config_key]
+        else:
+            return APPLICATION_INSTANCE.taxii_config
+    if config_group == "users":
+        if APPLICATION_INSTANCE.users_backend and config_key in APPLICATION_INSTANCE.users_backend:
+            return APPLICATION_INSTANCE.users_backend[config_key]
+        else:
+            return APPLICATION_INSTANCE.users_backend
+    if config_group == "backend":
+        if APPLICATION_INSTANCE.backend_config and config_key in APPLICATION_INSTANCE.backend_config:
+            return APPLICATION_INSTANCE.backend_config[config_key]
+        else:
+            return APPLICATION_INSTANCE.backend_config

--- a/medallion/scripts/run.py
+++ b/medallion/scripts/run.py
@@ -5,8 +5,10 @@ import os
 import textwrap
 
 from medallion import (
-    __version__, application_instance, register_blueprints, set_config
+    APPLICATION_INSTANCE, __version__, connect_to_backend, register_blueprints,
+    set_config
 )
+from medallion.common import get_application_instance_config_values
 import medallion.config
 
 log = logging.getLogger("medallion")
@@ -116,7 +118,7 @@ def main():
     medallion_args = medallion_parser.parse_args()
     # Configuration checking sets up debug logging and does not run the app
     if medallion_args.conf_check:
-        medallion_args.log_level = logging.DEBUG
+        medallion_args.log_level = logging.INFO
     log.setLevel(medallion_args.log_level)
 
     configuration = medallion.config.load_config(
@@ -124,13 +126,15 @@ def main():
         medallion_args.conf_dir if not medallion_args.no_conf_dir else None,
     )
 
-    set_config(application_instance, "users", configuration)
-    set_config(application_instance, "taxii", configuration)
-    set_config(application_instance, "backend", configuration)
-    register_blueprints(application_instance)
+    set_config(APPLICATION_INSTANCE, "users", configuration)
+    set_config(APPLICATION_INSTANCE, "taxii", configuration)
+    set_config(APPLICATION_INSTANCE, "backend", configuration)
+
+    APPLICATION_INSTANCE.medallion_backend = connect_to_backend(get_application_instance_config_values("backend"))
+    register_blueprints(APPLICATION_INSTANCE)
 
     if not medallion_args.conf_check:
-        application_instance.run(
+        APPLICATION_INSTANCE.run(
             host=medallion_args.host,
             port=medallion_args.port,
             debug=medallion_args.debug_mode,

--- a/medallion/test/base_test.py
+++ b/medallion/test/base_test.py
@@ -1,7 +1,10 @@
 import base64
 import os
 
-from medallion import application_instance, register_blueprints, set_config
+from medallion import connect_to_backend, register_blueprints, set_config
+from medallion.common import (
+    APPLICATION_INSTANCE, get_application_instance_config_values
+)
 from medallion.test.data.initialize_mongodb import reset_db
 
 
@@ -80,10 +83,10 @@ class TaxiiTest():
         },
     }
 
-    def setUp(self):
+    def setUp(self, start_threads=True):
         self.__name__ = self.type
-        self.app = application_instance
-        self.app_context = application_instance.app_context()
+        self.app = APPLICATION_INSTANCE
+        self.app_context = APPLICATION_INSTANCE.app_context()
         self.app_context.push()
         self.app.testing = True
         register_blueprints(self.app)
@@ -105,7 +108,10 @@ class TaxiiTest():
         set_config(self.app, "backend", self.configuration)
         set_config(self.app, "users", self.configuration)
         set_config(self.app, "taxii", self.configuration)
-        self.client = application_instance.test_client()
+        if not start_threads:
+            self.app.backend_config["run_cleanup_threads"] = False
+        APPLICATION_INSTANCE.medallion_backend = connect_to_backend(get_application_instance_config_values("backend"))
+        self.client = APPLICATION_INSTANCE.test_client()
         if self.type == "memory_no_config" or self.type == "no_auth":
             encoded_auth = "Basic " + \
                 base64.b64encode(b"user:pass").decode("ascii")

--- a/medallion/test/data/initialize_mongodb.py
+++ b/medallion/test/data/initialize_mongodb.py
@@ -1,6 +1,10 @@
+import datetime
+
 from pymongo import ASCENDING, IndexModel
 
-from medallion.common import datetime_to_float, string_to_datetime
+from medallion.common import (
+    datetime_to_float, datetime_to_string, string_to_datetime
+)
 from medallion.test.generic_initialize_mongodb import (
     add_api_root, build_new_mongo_databases_and_collection, connect_to_client
 )
@@ -84,6 +88,18 @@ def reset_db(url="mongodb://root:example@localhost:27017/"):
             "id": "2d086da7-4bdc-4f91-900e-f4566be4b780",
             "status": "pending",
             "request_timestamp": "2016-11-02T12:34:34.123456Z",
+            "total_objects": 0,
+            "success_count": 0,
+            "successes": [],
+            "failure_count": 0,
+            "failures": [],
+            "pending_count": 0,
+            "pendings": [],
+        },
+        {
+            "id": "5d086da7-4bdc-4f91-900e-f4566be4a680",
+            "status": "pending",
+            "request_timestamp": datetime_to_string(datetime.datetime.now()),
             "total_objects": 0,
             "success_count": 0,
             "successes": [],

--- a/sample-mongodb-config.json
+++ b/sample-mongodb-config.json
@@ -1,0 +1,6 @@
+{
+  "backend": {
+    "module_class": "MongoBackend",
+    "uri": "mongodb://localhost:27017/"
+  }
+}


### PR DESCRIPTION
two main things in each backend
- in get_collections, interop requires that the collection be sorted.  This may be enforced elsewhere, but you never know how backends are storing data
- added _pop_old_statuses

added backend config parameters
- status_retention - how long to keep statuses around
- run_cleanup_threads - enable/disable the cleanup threads _pop_old_statuses and _pop_expired_sessions - default is enabled (mostly for testing)