### PR TITLE
Raise 400 error on duplicate filter parameters

### DIFF
--- a/medallion/__init__.py
+++ b/medallion/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import warnings
 
-from flask import Response, current_app, json
+from flask import Response, current_app, json, request
 from flask_httpauth import HTTPBasicAuth
 
 from .backends import base as mbe_base
@@ -156,3 +156,10 @@ def handle_backend_error(error):
         status=error.status,
         mimetype=MEDIA_TYPE_TAXII_V21,
     )
+
+
+@APPLICATION_INSTANCE.before_request
+def validate_match_parameters():
+    for key, val in request.values.lists():
+        if len(val) > 1:
+            raise ProcessingError("The server can not process duplicate request or filter parameters", 400)

--- a/medallion/test/test_backends.py
+++ b/medallion/test/test_backends.py
@@ -1335,6 +1335,14 @@ def test_object_pagination_changing_params_400(backend):
     assert objs["title"] == "ProcessingError"
 
 
+def test_object_duplicate_match_filter_400(backend):
+    r = backend.client.get(
+            test.GET_OBJECTS_EP + "?match[type]=campaign&match[type]=malware",
+            headers=backend.headers
+    )
+    assert r.status_code == 400
+
+
 # test other config values
 # this may warrant some cleanup and organization later
 class TestTAXIIWithNoConfig(TaxiiTest):


### PR DESCRIPTION
To pass the [use case test in Section 3.13.1.10 of the TAXII 2.1 Interoperability Specification](https://docs.oasis-open.org/cti/taxii-2.1-interop/v1.0/csd01/taxii-2.1-interop-v1.0-csd01.html#_h684kvszq974).