### PR TITLE
Adapted timestamp string handling

### DIFF
--- a/medallion/common.py
+++ b/medallion/common.py
@@ -154,11 +154,11 @@ def float_to_datetime(timestamp_float):
 
 
 def string_to_datetime(timestamp_string):
-    """Convert string timestamp to datetime instance."""
-    try:
-        return dt.datetime.strptime(timestamp_string, "%Y-%m-%dT%H:%M:%S.%fZ")
-    except ValueError:
-        return dt.datetime.strptime(timestamp_string, "%Y-%m-%dT%H:%M:%SZ")
+    """Convert string timestamp to datetime instance. Handles Zero time and float seconds."""
+    timestamp_string = timestamp_string.strip('Z')
+    if '.' in timestamp_string:
+        return dt.datetime.strptime(timestamp_string, '%Y-%m-%d %H:%M:%S.%f')
+    return dt.datetime.strptime(timestamp_string, '%Y-%m-%d %H:%M:%S')
 
 
 def generate_status(


### PR DESCRIPTION
# Description
In the given process, when a timestamp string was being passed without the trailing Z, the function would crash with ValueError since `datetime` couldn't format the timestamp properly
# Solution
The implemented solution removes any trailing Z from the timestamp string, and read the timestamp as a `datetime` with floating point seconds if a `.` is present in the string, and as a normal `datetime` if there isn't
# Side effects and possible problems
the trailing Z indicates the zero hours offset, which is the same as no timezone provided. For this reason, it shouldn't create problems in the 23 functions using this function. Additionally, the following statement is true:
```
print(dt.datetime.strptime('2023-06-09T16:15:08.737003Z', '%Y-%m-%dT%H:%M:%S.%fZ') == (dt.datetime.strptime('2023-06-09T16:15:08.737003', '%Y-%m-%dT%H:%M:%S.%f')))
```